### PR TITLE
Ft remove inverse dynamics

### DIFF
--- a/albertReacher/envs/acc.py
+++ b/albertReacher/envs/acc.py
@@ -8,7 +8,7 @@ class AlbertReacherAccEnv(AlbertReacherEnv):
         return ob
 
     def applyAction(self, action):
-        self.robot.apply_acc_action(action)
+        self.robot.apply_acc_action(action, self._dt)
 
     def setSpaces(self):
         (self.observation_space, self.action_space) = self.robot.getAccSpaces()

--- a/albertReacher/envs/albertReacherEnv.py
+++ b/albertReacher/envs/albertReacherEnv.py
@@ -23,8 +23,8 @@ class AlbertReacherEnv(UrdfEnv):
         pass
 
     def reset(self, initialSet=False, pos=None, vel=None):
-        if not isinstance(pos, np.ndarray) or not pos.size == self._n:
-            pos = np.zeros(self._n)
+        if not isinstance(pos, np.ndarray) or not pos.size == self._n+1:
+            pos = np.zeros(self._n+1)
         if not isinstance(vel, np.ndarray) or not vel.size == self._n:
             vel = np.zeros(self._n)
         if not initialSet:

--- a/albertReacher/envs/tor.py
+++ b/albertReacher/envs/tor.py
@@ -10,6 +10,7 @@ class AlbertReacherTorEnv(AlbertReacherEnv):
         return ob
 
     def applyAction(self, action):
+        self.robot.apply_base_velocity(action)
         self.robot.apply_torque_action(action)
 
     def setSpaces(self):

--- a/albertReacher/envs/vel.py
+++ b/albertReacher/envs/vel.py
@@ -3,6 +3,7 @@ from albertReacher.envs.albertReacherEnv import AlbertReacherEnv
 
 class AlbertReacherVelEnv(AlbertReacherEnv):
     def applyAction(self, action):
+        self.robot.apply_base_velocity(action)
         self.robot.apply_vel_action(action)
 
     def setSpaces(self):

--- a/examples/albert.py
+++ b/examples/albert.py
@@ -13,8 +13,9 @@ def main():
     n_episodes = 1
     n_steps = 100000
     cumReward = 0.0
+    pos0 = np.zeros(10)
     for e in range(n_episodes):
-        ob = env.reset()
+        ob = env.reset(pos=pos0)
         print("Starting episode")
         for i in range(n_steps):
             action = env.action_space.sample()

--- a/examples/mobile_reacher.py
+++ b/examples/mobile_reacher.py
@@ -8,7 +8,7 @@ def main():
     #env = gym.make('mobile-reacher-vel-v0', dt=0.01, render=True)
     env = gym.make('mobile-reacher-acc-v0', dt=0.01, render=True, gripper=False)
     defaultAction = np.zeros(10)
-    defaultAction[2] = 0.0
+    defaultAction[0] = 0.1
     defaultAction[5] = -0.0
     defaultAction[-1] = 3.5
     n_episodes = 1

--- a/mobileReacher/envs/acc.py
+++ b/mobileReacher/envs/acc.py
@@ -9,7 +9,7 @@ class MobileReacherAccEnv(MobileReacherEnv):
         return ob
 
     def applyAction(self, action):
-        self.robot.apply_acc_action(action)
+        self.robot.apply_acc_action(action, self.dt())
 
     def setSpaces(self):
         (self.observation_space, self.action_space) = self.robot.getAccSpaces()

--- a/mobileReacher/resources/mobileRobot.py
+++ b/mobileReacher/resources/mobileRobot.py
@@ -46,6 +46,7 @@ class MobileRobot:
         for i in range(pre_steps):
             p.stepSimulation()
         print("Reached initial position")
+        self._vels_int = vel
 
     def getLimits(self):
         return (self._limitPos_j, self._limitVel_j, self._limitTor_j, self._limitAcc_j)
@@ -115,19 +116,9 @@ class MobileRobot:
                                         controlMode=p.TORQUE_CONTROL,
                                         force=torques[i])
 
-    def apply_acc_action(self, accs):
-        q = []
-        qdot = []
-        qddot = []
-        for i in range(self._n):
-            pos, vel, _, _= p.getJointState(self.robot, self.control_joints[i])
-            q.append(pos)
-            qdot.append(vel)
-        qddot = list(accs)
-        q = list(q)
-        qdot = list(qdot)
-        tau = p.calculateInverseDynamics(self.robot, q, qdot, qddot)
-        self.apply_torque_action(tau)
+    def apply_acc_action(self, accs, dt):
+        self._vels_int += dt * accs
+        self.apply_vel_action(self._vels_int)
 
     def apply_vel_action(self, vels):
         for i in range(self._n):

--- a/tiagoReacher/resources/tiagoRobot.py
+++ b/tiagoReacher/resources/tiagoRobot.py
@@ -13,6 +13,7 @@ class TiagoRobot:
         self.setJointIdsUrdf()
         self.readLimits()
         self._r = 0.1
+        self._l = 0.4044
 
     def n(self):
         return self._n
@@ -148,15 +149,18 @@ class TiagoRobot:
                 controlMode=p.TORQUE_CONTROL,
                 force=torques[i],
             )
+        self.updateState()
 
     def apply_acc_action(self, accs, dt):
         self._vels_int += dt * accs
         self.apply_base_velocity(self._vels_int)
         self.apply_vel_action(self._vels_int)
+        self.updateState()
 
     def apply_base_velocity(self, vels):
-        vels = np.array([vels[0] + vels[1], vels[0] - vels[1]])
-        wheelVels = vels / self._r
+        vel_left = (vels[0] - 0.5 * self._l * vels[1]) / self._r
+        vel_right = (vels[0] + 0.5 * self._l * vels[1]) / self._r
+        wheelVels = np.array([vel_right, vel_left])
         self.apply_vel_action_wheels(wheelVels)
 
     def apply_vel_action_wheels(self, vels):
@@ -176,6 +180,7 @@ class TiagoRobot:
                 controlMode=p.VELOCITY_CONTROL,
                 targetVelocity=vels[i],
             )
+        self.updateState()
 
     def updateState(self):
         # Get Base State


### PR DESCRIPTION
This pull-requests removes the inverse dynamics for the mobileRobot and the albert.
Instead, it makes use of an integration scheme with the velocity controller. 

Decided to keep the panda and pointMass with inverse dynamics as it works for non-differential-drive robots and is the better solution.

Solves #12 