### PR TITLE
Ft dict spaces

### DIFF
--- a/albertReacher/resources/albertRobot.py
+++ b/albertReacher/resources/albertRobot.py
@@ -5,10 +5,10 @@ import math
 from urdfpy import URDF
 import numpy as np
 
-from urdfCommon.diffDriveRobot import DiffDriveRobot
+from urdfCommon.differentialDriveRobot import DifferentialDriveRobot
 
 
-class AlbertRobot(DiffDriveRobot):
+class AlbertRobot(DifferentialDriveRobot):
     def __init__(self):
         n = 9
         fileName = os.path.join(os.path.dirname(__file__), 'albert.urdf')

--- a/boxerRobot/resources/boxerRobot.py
+++ b/boxerRobot/resources/boxerRobot.py
@@ -2,10 +2,10 @@ import pybullet as p
 import os
 import numpy as np
 
-from urdfCommon.diffDriveRobot import DiffDriveRobot
+from urdfCommon.differentialDriveRobot import DifferentialDriveRobot
 
 
-class BoxerRobot(DiffDriveRobot):
+class BoxerRobot(DifferentialDriveRobot):
     def __init__(self):
         n = 2
         fileName = os.path.join(os.path.dirname(__file__), 'boxer.urdf')

--- a/boxerRobot/resources/boxerRobot.py
+++ b/boxerRobot/resources/boxerRobot.py
@@ -2,10 +2,10 @@ import pybullet as p
 import os
 import numpy as np
 
-from urdfCommon.abstractRobot import AbstractRobot
+from urdfCommon.diffDriveRobot import DiffDriveRobot
 
 
-class BoxerRobot(AbstractRobot):
+class BoxerRobot(DiffDriveRobot):
     def __init__(self):
         n = 2
         fileName = os.path.join(os.path.dirname(__file__), 'boxer.urdf')
@@ -18,72 +18,7 @@ class BoxerRobot(AbstractRobot):
         self.robot_joints = [3, 4]
         self.castor_joints = [1, 2]
 
-    def n(self):
-        return self._n
-
-    def reset(self, pos=None, vel=None):
-        if hasattr(self, "robot"):
-            p.resetSimulation()
-        baseOrientation = p.getQuaternionFromEuler([0, 0, pos[2]])
-        self.robot = p.loadURDF(
-            fileName=self.fileName,
-            basePosition=[pos[0], pos[1], 0.05],
-            baseOrientation=baseOrientation,
-            flags=p.URDF_USE_SELF_COLLISION_EXCLUDE_PARENT,
-        )
-        # Joint indices as found by p.getJointInfo()
-        # set castor wheel friction to zero
-        # print(self.getIndexedJointInfo())
-        for i in self.castor_joints:
-            p.setJointMotorControl2(
-                self.robot,
-                jointIndex=i,
-                controlMode=p.VELOCITY_CONTROL,
-                force=0.0
-            )
-        # set base velocity
-        self.updateState()
-        self._vels_int = vel
-
     def setAccLimits(self):
         accLimit = np.array([1.0, 1.0])
         self._limitAcc_j[0, :] = -accLimit
         self._limitAcc_j[1, :] = accLimit
-
-    def apply_acc_action(self, accs, dt):
-        self._vels_int += dt * accs
-        self._vels_int = np.clip(self._vels_int, -np.ones(2), np.ones(2))
-        #self._vels_int = self.state[3:5]
-        self.apply_base_velocity(self._vels_int)
-
-    def apply_vel_action_wheels(self, vels):
-        for i in range(2):
-            p.setJointMotorControl2(self.robot, self.robot_joints[i],
-                                        controlMode=p.VELOCITY_CONTROL,
-                                        targetVelocity=vels[i])
-
-    def apply_base_velocity(self, vels):
-        vel_left = (vels[0] - 0.5 * self._l * vels[1]) / self._r
-        vel_right = (vels[0] + 0.5 * self._l * vels[1]) / self._r
-        wheelVels = np.array([vel_right, vel_left])
-        self.apply_vel_action_wheels(wheelVels)
-
-    def updateState(self):
-        # Get Base State
-        linkState = p.getLinkState(self.robot, 0, computeLinkVelocity=0)
-        posBase = np.array(
-            [
-                linkState[0][0],
-                linkState[0][1],
-                p.getEulerFromQuaternion(linkState[1])[2],
-            ]
-        )
-        velWheels = p.getJointStates(self.robot, self.robot_joints)
-        v_right = velWheels[0][1]
-        v_left = velWheels[1][1]
-        vf = np.array([0.5 * (v_right + v_left) * self._r, (v_right - v_left) * self._r / self._l])
-        Jnh = np.array([[np.cos(posBase[2]), 0], [np.sin(posBase[2]), 0], [0, 1]])
-        velBase = np.dot(Jnh, vf)
-
-        self.state = np.concatenate((posBase, vf, velBase))
-

--- a/mobileReacher/resources/mobileRobot.py
+++ b/mobileReacher/resources/mobileRobot.py
@@ -2,10 +2,10 @@ import pybullet as p
 import os
 import numpy as np
 
-from urdfCommon.abstractRobot import AbstractRobot
+from urdfCommon.holonomicRobot import HolonomicRobot
 
 
-class MobileRobot(AbstractRobot):
+class MobileRobot(HolonomicRobot):
     def __init__(self, gripper=False):
         self._gripper = gripper
         if gripper:

--- a/nLinkUrdfReacher/resources/nLinkRobot.py
+++ b/nLinkUrdfReacher/resources/nLinkRobot.py
@@ -1,10 +1,10 @@
 import os
 import numpy as np
 
-from urdfCommon.abstractRobot import AbstractRobot
+from urdfCommon.holonomicRobot import HolonomicRobot
 
 
-class NLinkRobot(AbstractRobot):
+class NLinkRobot(HolonomicRobot):
     def __init__(self, n):
         fileName = os.path.join(os.path.dirname(__file__), 'nlink_' + str(n) + '.urdf')
         super().__init__(n, fileName)

--- a/pandaReacher/envs/pandaReacherEnv.py
+++ b/pandaReacher/envs/pandaReacherEnv.py
@@ -15,6 +15,9 @@ class PandaReacherEnv(UrdfEnv):
             pos[3] = -1.501
             pos[5] = 1.8675
             pos[6] = np.pi/4
+            if self.robot.n() > 7:
+                pos[7] = 0.02
+                pos[8] = 0.02
         if not isinstance(vel, np.ndarray) or not vel.size == self.robot.n():
             vel = np.zeros(self.robot.n())
         return pos, vel

--- a/pandaReacher/resources/pandaRobot.py
+++ b/pandaReacher/resources/pandaRobot.py
@@ -1,10 +1,10 @@
 import os
 import numpy as np
 
-from urdfCommon.abstractRobot import AbstractRobot
+from urdfCommon.holonomicRobot import HolonomicRobot
 
 
-class PandaRobot(AbstractRobot):
+class PandaRobot(HolonomicRobot):
     def __init__(self, gripper=False, friction=0.0):
         self._gripper = gripper
         self._friction = friction

--- a/pointRobotUrdf/resources/pointRobot.py
+++ b/pointRobotUrdf/resources/pointRobot.py
@@ -1,10 +1,10 @@
 import os
 import numpy as np
 
-from urdfCommon.abstractRobot import AbstractRobot
+from urdfCommon.holonomicRobot import HolonomicRobot
 
 
-class PointRobot(AbstractRobot):
+class PointRobot(HolonomicRobot):
     def __init__(self):
         fileName = os.path.join(os.path.dirname(__file__), 'pointRobot.urdf')
         n = 2

--- a/sensors/lidar.py
+++ b/sensors/lidar.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pybullet as p
+import gym
+
 
 class Lidar(object):
 
@@ -9,15 +11,21 @@ class Lidar(object):
         self._linkId = linkId
         self._thetas = [i * 2*np.pi/self._nbRays for i in range(self._nbRays)]
         self._relPositions = np.zeros(2*nbRays)
+        self._name = "lidarSensor"
+
+    def name(self):
+        return self._name
 
     def getOSpaceSize(self):
         return self._nbRays * 2
+
+    def getObservationSpace(self):
+        return gym.spaces.Box(-10, 10, shape=(self.getOSpaceSize(), ), dtype=np.float64)
 
     def sense(self, robot):
         linkState = p.getLinkState(robot, self._linkId)
         lidarPosition = linkState[0]
         rayStart = lidarPosition
-        thetas = []
         for i, theta in enumerate(self._thetas):
             rayEnd = np.array(rayStart) + self._rayLength * np.array([np.cos(theta), np.sin(theta), 0.0])
             lidar = p.rayTest(rayStart, rayEnd)

--- a/tiagoReacher/envs/tiagoReacherEnv.py
+++ b/tiagoReacher/envs/tiagoReacherEnv.py
@@ -13,6 +13,7 @@ class TiagoReacherEnv(UrdfEnv):
     def checkInitialState(self, pos, vel):
         if not isinstance(pos, np.ndarray) or not pos.size == self.robot.n() + 1:
             pos = np.zeros(self.robot.n()+1)
+            pos[3] = 0.1
         if not isinstance(vel, np.ndarray) or not vel.size == self.robot.n():
             vel = np.zeros(self.robot.n())
         return pos, vel

--- a/tiagoReacher/envs/vel.py
+++ b/tiagoReacher/envs/vel.py
@@ -6,3 +6,6 @@ class TiagoReacherVelEnv(TiagoReacherEnv):
     def applyAction(self, action):
         self.robot.apply_base_velocity(action)
         self.robot.apply_vel_action(action)
+
+    def setSpaces(self):
+        (self.observation_space, self.action_space) = self.robot.getVelSpaces()

--- a/tiagoReacher/resources/tiagoRobot.py
+++ b/tiagoReacher/resources/tiagoRobot.py
@@ -5,10 +5,10 @@ import math
 from urdfpy import URDF
 import numpy as np
 
-from urdfCommon.abstractRobot import AbstractRobot
+from urdfCommon.diffDriveRobot import DiffDriveRobot
 
 
-class TiagoRobot(AbstractRobot):
+class TiagoRobot(DiffDriveRobot):
     def __init__(self):
         n = 19
         self._r = 0.1
@@ -19,7 +19,7 @@ class TiagoRobot(AbstractRobot):
     def setJointIndices(self):
         self.robot_joints = [6, 8, 18, 19, 20, 22, 23, 24, 25, 26, 27, 28, 37, 38, 39, 40, 41, 42, 43]
         self.urdf_joints = [6, 8, 19, 20, 21, 23, 24, 25, 26, 27, 28, 29, 38, 39, 40, 41, 42, 43, 44]
-        self.caster_joints = [9, 10, 11, 12, 13, 14, 15, 16]
+        self.castor_joints = [9, 10, 11, 12, 13, 14, 15, 16]
         # TODO: This could be used as a starting point to get joint indices from urdf <01-12-21, mspahn> #
         """
         wheel_joint_names = ["wheel_right_joint", "wheel_left_joint"]
@@ -52,113 +52,8 @@ class TiagoRobot(AbstractRobot):
         self.robot_joints_gripper = []
         """
 
-    def reset(self, pos=np.zeros(20), vel=np.zeros(19)):
-        if hasattr(self, "robot"):
-            p.resetSimulation()
-        baseOrientation = p.getQuaternionFromEuler([0, 0, pos[2]])
-        self.robot = p.loadURDF(
-            fileName=self.fileName,
-            basePosition=[pos[0], pos[1], 0.15],
-            baseOrientation=baseOrientation,
-            flags=p.URDF_USE_SELF_COLLISION_EXCLUDE_PARENT,
-        )
-        # set castor wheel friction to zero
-        for i in self.caster_joints:
-            p.setJointMotorControl2(
-                self.robot, jointIndex=i, controlMode=p.VELOCITY_CONTROL, force=0.0
-            )
-        # set base velocity
-        v = np.zeros(2)
-        v[0] = vel[0] + vel[1]
-        v[1] = vel[0] - vel[0]
-        for i in range(2, self._n):
-            p.resetJointState(
-                self.robot,
-                self.robot_joints[i],
-                pos[i + 1],
-                targetVelocity=vel[i],
-            )
-        self.updateState()
-        self.apply_vel_action_wheels(v)
-        self.apply_vel_action(vel)
-        self.state[-2:] = v
-        self._vels_int = np.concatenate((self.state[40:42], self.state[23:40]))
-
     def setAccLimits(self):
         accLimit = np.ones(self._n)
         self._limitAcc_j[0, :] = -accLimit
         self._limitAcc_j[1, :] = accLimit
 
-    def disableVelocityControl(self, friction):
-        for i in range(2, self._n):
-            p.setJointMotorControl2(
-                self.robot,
-                jointIndex=self.robot_joints[i],
-                controlMode=p.VELOCITY_CONTROL,
-                force=friction,
-            )
-
-    def apply_torque_action(self, torques):
-        for i in range(2, self._n):
-            p.setJointMotorControl2(
-                self.robot,
-                self.robot_joints[i],
-                controlMode=p.TORQUE_CONTROL,
-                force=torques[i],
-            )
-
-    def apply_acc_action(self, accs, dt):
-        self._vels_int += dt * accs
-        self.apply_base_velocity(self._vels_int)
-        self.apply_vel_action(self._vels_int)
-
-    def apply_base_velocity(self, vels):
-        vel_left = (vels[0] - 0.5 * self._l * vels[1]) / self._r
-        vel_right = (vels[0] + 0.5 * self._l * vels[1]) / self._r
-        wheelVels = np.array([vel_right, vel_left])
-        self.apply_vel_action_wheels(wheelVels)
-
-    def apply_vel_action_wheels(self, vels):
-        for i in range(2):
-            p.setJointMotorControl2(
-                self.robot,
-                self.robot_joints[i],
-                controlMode=p.VELOCITY_CONTROL,
-                targetVelocity=vels[i],
-            )
-
-    def apply_vel_action(self, vels):
-        for i in range(2, self._n):
-            p.setJointMotorControl2(
-                self.robot,
-                self.robot_joints[i],
-                controlMode=p.VELOCITY_CONTROL,
-                targetVelocity=vels[i],
-            )
-
-    def updateState(self):
-        # Get Base State
-        linkState = p.getLinkState(self.robot, 0, computeLinkVelocity=1)
-        posBase = np.array(
-            [
-                linkState[0][0],
-                linkState[0][1],
-                p.getEulerFromQuaternion(linkState[1])[2],
-            ]
-        )
-        velBase = np.array([linkState[6][0], linkState[6][1], linkState[7][2]])
-        # Get Joint Configurations
-        joint_pos_list = []
-        joint_vel_list = []
-        for i in range(2, self._n):
-            pos, vel, _, _ = p.getJointState(self.robot, self.robot_joints[i])
-            joint_pos_list.append(pos)
-            joint_vel_list.append(vel)
-        joint_pos = np.array(joint_pos_list)
-        joint_vel = np.array(joint_vel_list)
-
-        # forward and rotational velocity
-        vf = np.array([np.sqrt(velBase[0] ** 2 + velBase[1] ** 2), velBase[2]])
-
-        # Concatenate position[0:20], velocity[0:20], vf[0:2]
-        self.state = np.concatenate((posBase, joint_pos, velBase, joint_vel, vf))

--- a/tiagoReacher/resources/tiagoRobot.py
+++ b/tiagoReacher/resources/tiagoRobot.py
@@ -5,10 +5,10 @@ import math
 from urdfpy import URDF
 import numpy as np
 
-from urdfCommon.diffDriveRobot import DiffDriveRobot
+from urdfCommon.differentialDriveRobot import DifferentialDriveRobot
 
 
-class TiagoRobot(DiffDriveRobot):
+class TiagoRobot(DifferentialDriveRobot):
     def __init__(self):
         n = 19
         self._r = 0.1

--- a/tiagoReacher/resources/tiago_dual.urdf
+++ b/tiagoReacher/resources/tiago_dual.urdf
@@ -576,7 +576,7 @@
     <parent link="torso_fixed_link"/>
     <child link="torso_lift_link"/>
     <axis xyz="0 0 1"/>
-    <limit effort="2000" lower="0" upper="0.35" velocity="0.07"/>
+    <limit effort="2000" lower="0" upper="0.35" velocity="0.35"/>
     <calibration rising="0.0"/>
     <dynamics damping="1000"/>
     <safety_controller k_position="20" k_velocity="20" soft_lower_limit="0.0" soft_upper_limit="0.35"/>

--- a/urdfCommon/diffDriveRobot.py
+++ b/urdfCommon/diffDriveRobot.py
@@ -135,7 +135,7 @@ class DiffDriveRobot(AbstractRobot):
         joint_vel = np.array(joint_vel_list)
 
         # Concatenate position[0:10], velocity[0:10], vf[0:3]
-        self.state = {'x': np.concatenate((posBase, joint_pos)), 'vel': vf, 'xdot': np.concatenate((joint_vel, velBase))}
+        self.state = {'x': np.concatenate((posBase, joint_pos)), 'vel': vf, 'xdot': np.concatenate((velBase, joint_vel))}
 
     def updateSensing(self):
         self.sensor_observation = {}

--- a/urdfCommon/diffDriveRobot.py
+++ b/urdfCommon/diffDriveRobot.py
@@ -1,6 +1,4 @@
 import pybullet as p
-import pybullet_data
-from abc import ABC, abstractmethod
 import gym
 from urdfpy import URDF
 import numpy as np
@@ -21,7 +19,7 @@ class DiffDriveRobot(AbstractRobot):
         baseOrientation = p.getQuaternionFromEuler([0, 0, pos[2]])
         self.robot = p.loadURDF(
             fileName=self.fileName,
-            basePosition=[pos[0], pos[1], 0.05],
+            basePosition=[pos[0], pos[1], 0.15],
             baseOrientation=baseOrientation,
             flags=p.URDF_USE_SELF_COLLISION_EXCLUDE_PARENT,
         )
@@ -34,6 +32,13 @@ class DiffDriveRobot(AbstractRobot):
                 jointIndex=i,
                 controlMode=p.VELOCITY_CONTROL,
                 force=0.0
+            )
+        for i in range(2, self._n):
+            p.resetJointState(
+                self.robot, 
+                self.robot_joints[i],
+                pos[i + 1],
+                targetVelocity=vel[i],
             )
         # set base velocity
         self.updateState()

--- a/urdfCommon/diffDriveRobot.py
+++ b/urdfCommon/diffDriveRobot.py
@@ -1,0 +1,148 @@
+import pybullet as p
+import pybullet_data
+from abc import ABC, abstractmethod
+import gym
+from urdfpy import URDF
+import numpy as np
+
+from urdfCommon.abstractRobot import AbstractRobot
+
+
+class DiffDriveRobot(AbstractRobot):
+    def __init__(self, n, fileName):
+        super().__init__(n, fileName)
+
+    def ns(self):
+        return self.n() + 1
+
+    def reset(self, pos=None, vel=None):
+        if hasattr(self, "robot"):
+            p.resetSimulation()
+        baseOrientation = p.getQuaternionFromEuler([0, 0, pos[2]])
+        self.robot = p.loadURDF(
+            fileName=self.fileName,
+            basePosition=[pos[0], pos[1], 0.05],
+            baseOrientation=baseOrientation,
+            flags=p.URDF_USE_SELF_COLLISION_EXCLUDE_PARENT,
+        )
+        # Joint indices as found by p.getJointInfo()
+        # set castor wheel friction to zero
+        # print(self.getIndexedJointInfo())
+        for i in self.castor_joints:
+            p.setJointMotorControl2(
+                self.robot,
+                jointIndex=i,
+                controlMode=p.VELOCITY_CONTROL,
+                force=0.0
+            )
+        # set base velocity
+        self.updateState()
+        self._vels_int = vel
+
+    def readLimits(self):
+        robot = URDF.load(self.fileName)
+        self._limitPos_j = np.zeros((2, self.ns()))
+        self._limitVel_j = np.zeros((2, self.ns()))
+        self._limitTor_j = np.zeros((2, self.n()))
+        self._limitAcc_j = np.zeros((2, self.n()))
+        for i in range(self.n()):
+            joint = robot.joints[self.urdf_joints[i]]
+            print(joint.name)
+            self._limitTor_j[0, i] = -joint.limit.effort
+            self._limitTor_j[1, i] = joint.limit.effort
+            if i >= 2:
+                self._limitPos_j[0, i+1] = joint.limit.lower
+                self._limitPos_j[1, i+1] = joint.limit.upper
+                self._limitVel_j[0, i+1] = -joint.limit.velocity
+                self._limitVel_j[1, i+1] = joint.limit.velocity
+        self._limitVelForward_j = np.array([[-4, -10], [4, 10]])
+        self._limitPos_j[0, 0:3] = np.array([-10, -10, -2 * np.pi])
+        self._limitPos_j[1, 0:3] = np.array([10, 10, 2 * np.pi])
+        self._limitVel_j[0, 0:3] = np.array([-4, -4, -10])
+        self._limitVel_j[1, 0:3] = np.array([4, 4, 10])
+        self.setAccLimits()
+
+    def getLimits(self):
+        return (self._limitPos_j, self._limitVel_j, self._limitTor_j)
+
+    def getObservationSpace(self):
+        return gym.spaces.Dict({
+            'x': gym.spaces.Box(low=self._limitPos_j[0, :], high=self._limitPos_j[1, :], dtype=np.float64), 
+            'vel': gym.spaces.Box(low=self._limitVelForward_j[0, :], high=self._limitVelForward_j[1, :], dtype=np.float64),
+            'xdot': gym.spaces.Box(low=self._limitVel_j[0, :], high=self._limitVel_j[1, :], dtype=np.float64), 
+        })
+
+    def apply_torque_action(self, torques):
+        for i in range(2, self._n):
+            p.setJointMotorControl2(self.robot, self.robot_joints[i],
+                                        controlMode=p.TORQUE_CONTROL,
+                                        force=torques[i])
+
+    def apply_acc_action(self, accs, dt):
+        self._vels_int += dt * accs
+        self._vels_int[0] = np.clip(self._vels_int[0], 0.7 * self._limitVelForward_j[0, 0], 0.7 * self._limitVelForward_j[1, 0])
+        self._vels_int[1] = np.clip(self._vels_int[1], 0.5 * self._limitVelForward_j[0, 1], 0.5 * self._limitVelForward_j[1, 1])
+        self.apply_base_velocity(self._vels_int)
+        self.apply_vel_action(self._vels_int)
+
+    def apply_vel_action_wheels(self, vels):
+        for i in range(2):
+            p.setJointMotorControl2(self.robot, self.robot_joints[i],
+                                        controlMode=p.VELOCITY_CONTROL,
+                                        targetVelocity=vels[i])
+
+    def apply_base_velocity(self, vels):
+        vel_left = (vels[0] - 0.5 * self._l * vels[1]) / self._r
+        vel_right = (vels[0] + 0.5 * self._l * vels[1]) / self._r
+        wheelVels = np.array([vel_right, vel_left])
+        self.apply_vel_action_wheels(wheelVels)
+
+    def apply_vel_action(self, vels):
+        for i in range(2, self._n):
+            p.setJointMotorControl2(self.robot, self.robot_joints[i],
+                                        controlMode=p.VELOCITY_CONTROL,
+                                        targetVelocity=vels[i])
+
+    def updateState(self):
+        # Get Base State
+        linkState = p.getLinkState(self.robot, 0, computeLinkVelocity=0)
+        posBase = np.array(
+            [
+                linkState[0][0],
+                linkState[0][1],
+                p.getEulerFromQuaternion(linkState[1])[2],
+            ]
+        )
+        velWheels = p.getJointStates(self.robot, self.robot_joints)
+        v_right = velWheels[0][1]
+        v_left = velWheels[1][1]
+        vf = np.array([0.5 * (v_right + v_left) * self._r, (v_right - v_left) * self._r / self._l])
+        Jnh = np.array([[np.cos(posBase[2]), 0], [np.sin(posBase[2]), 0], [0, 1]])
+        velBase = np.dot(Jnh, vf)
+        # Get Joint Configurations
+        joint_pos_list = []
+        joint_vel_list = []
+        for i in range(2, self._n):
+            pos, vel, _, _ = p.getJointState(self.robot, self.robot_joints[i])
+            joint_pos_list.append(pos)
+            joint_vel_list.append(vel)
+        joint_pos = np.array(joint_pos_list)
+        joint_vel = np.array(joint_vel_list)
+
+        # Concatenate position[0:10], velocity[0:10], vf[0:3]
+        self.state = {'x': np.concatenate((posBase, joint_pos)), 'vel': vf, 'xdot': np.concatenate((joint_vel, velBase))}
+
+    def updateSensing(self):
+        self.sensor_observation = {}
+        for sensor in self._sensors:
+            self.sensor_observation[sensor.name()] = sensor.sense(self.robot)
+
+    def get_observation(self):
+        self.updateState()
+        self.updateSensing()
+        return {**self.state, **self.sensor_observation}
+
+    def addSensor(self, sensor):
+        self._sensors.append(sensor)
+        return sensor.getOSpaceSize()
+

--- a/urdfCommon/differentialDriveRobot.py
+++ b/urdfCommon/differentialDriveRobot.py
@@ -3,10 +3,10 @@ import gym
 from urdfpy import URDF
 import numpy as np
 
-from urdfCommon.abstractRobot import AbstractRobot
+from urdfCommon.genericRobot import GenericRobot
 
 
-class DiffDriveRobot(AbstractRobot):
+class DifferentialDriveRobot(GenericRobot):
     def __init__(self, n, fileName):
         super().__init__(n, fileName)
 
@@ -66,9 +66,6 @@ class DiffDriveRobot(AbstractRobot):
         self._limitVel_j[0, 0:3] = np.array([-4, -4, -10])
         self._limitVel_j[1, 0:3] = np.array([4, 4, 10])
         self.setAccLimits()
-
-    def getLimits(self):
-        return (self._limitPos_j, self._limitVel_j, self._limitTor_j)
 
     def getObservationSpace(self):
         return gym.spaces.Dict({
@@ -136,18 +133,4 @@ class DiffDriveRobot(AbstractRobot):
 
         # Concatenate position[0:10], velocity[0:10], vf[0:3]
         self.state = {'x': np.concatenate((posBase, joint_pos)), 'vel': vf, 'xdot': np.concatenate((velBase, joint_vel))}
-
-    def updateSensing(self):
-        self.sensor_observation = {}
-        for sensor in self._sensors:
-            self.sensor_observation[sensor.name()] = sensor.sense(self.robot)
-
-    def get_observation(self):
-        self.updateState()
-        self.updateSensing()
-        return {**self.state, **self.sensor_observation}
-
-    def addSensor(self, sensor):
-        self._sensors.append(sensor)
-        return sensor.getOSpaceSize()
 

--- a/urdfCommon/genericRobot.py
+++ b/urdfCommon/genericRobot.py
@@ -1,0 +1,113 @@
+import pybullet as p
+from abc import ABC, abstractmethod
+import gym
+import numpy as np
+
+
+class GenericRobot(ABC):
+    def __init__(self, n, fileName):
+        self._n = n
+        self.fileName = fileName
+        self.setJointIndices()
+        self.readLimits()
+        self._sensors = []
+
+    def n(self):
+        return self._n
+
+    @abstractmethod
+    def reset(self, pos, vel):
+        pass
+
+    @abstractmethod
+    def setJointIndices(self):
+        pass
+
+    @abstractmethod
+    def readLimits(self):
+        pass
+
+    @abstractmethod
+    def setAccLimits(self):
+        pass
+
+    def getIndexedJointInfo(self):
+        indexedJointInfo = {}
+        for i in range(p.getNumJoints(self.robot)):
+            jointInfo = p.getJointInfo(self.robot, i)
+            indexedJointInfo[jointInfo[0]] = jointInfo[1]
+        return indexedJointInfo
+
+    def getLimits(self):
+        return (self._limitPos_j, self._limitVel_j, self._limitTor_j)
+
+    def getTorqueSpaces(self):
+        ospace = self.getObservationSpace()
+        uu = self._limitTor_j[1, :]
+        ul = self._limitTor_j[0, :]
+        aspace = gym.spaces.Box(low=ul, high=uu, dtype=np.float64)
+        return (ospace, aspace)
+
+    def getObservationSpace(self):
+        return gym.spaces.Dict({
+            'x': gym.spaces.Box(low=self._limitPos_j[0, :], high=self._limitPos_j[1, :], dtype=np.float64), 
+            'xdot': gym.spaces.Box(low=self._limitVel_j[0, :], high=self._limitVel_j[1, :], dtype=np.float64), 
+        })
+
+    def getVelSpaces(self):
+        ospace = self.getObservationSpace()
+        uu = self._limitVel_j[1, :]
+        ul = self._limitVel_j[0, :]
+        aspace = gym.spaces.Box(low=ul, high=uu, dtype=np.float64)
+        return (ospace, aspace)
+
+    def getAccSpaces(self):
+        ospace = self.getObservationSpace()
+        uu = self._limitAcc_j[1, :]
+        ul = self._limitAcc_j[0, :]
+        aspace = gym.spaces.Box(low=ul, high=uu, dtype=np.float64)
+        return (ospace, aspace)
+
+    def disableVelocityControl(self):
+        self._friction = 0.0
+        for i in range(self._n):
+            p.setJointMotorControl2(
+                self.robot,
+                jointIndex=self.robot_joints[i],
+                controlMode=p.VELOCITY_CONTROL,
+                force=self._friction,
+            )
+
+    def get_ids(self):
+        return self.robot
+
+    @abstractmethod
+    def apply_torque_action(self, torques):
+        pass
+
+    @abstractmethod
+    def apply_vel_action(self, vels):
+        pass
+
+    @abstractmethod
+    def apply_acc_action(self, accs):
+        pass
+
+    @abstractmethod
+    def updateState(self):
+        pass
+
+    def updateSensing(self):
+        self.sensor_observation = {}
+        for sensor in self._sensors:
+            self.sensor_observation[sensor.name()] = sensor.sense(self.robot)
+
+    def get_observation(self):
+        self.updateState()
+        self.updateSensing()
+        return {**self.state, **self.sensor_observation}
+
+    def addSensor(self, sensor):
+        self._sensors.append(sensor)
+        return sensor.getOSpaceSize()
+

--- a/urdfCommon/holonomicRobot.py
+++ b/urdfCommon/holonomicRobot.py
@@ -5,17 +5,12 @@ import gym
 from urdfpy import URDF
 import numpy as np
 
+from urdfCommon.genericRobot import GenericRobot
 
-class AbstractRobot(ABC):
+
+class HolonomicRobot(GenericRobot):
     def __init__(self, n, fileName):
-        self._n = n
-        self.fileName = fileName
-        self.setJointIndices()
-        self.readLimits()
-        self._sensors = []
-
-    def n(self):
-        return self._n
+        super().__init__(n, fileName)
 
     def reset(self, pos, vel):
         if hasattr(self, "robot"):
@@ -34,9 +29,6 @@ class AbstractRobot(ABC):
             )
         self.updateState()
 
-    @abstractmethod
-    def setJointIndices(self):
-        pass
 
     def readLimits(self):
         robot = URDF.load(self.fileName)
@@ -55,59 +47,11 @@ class AbstractRobot(ABC):
             self._limitTor_j[1, i] = joint.limit.effort
         self.setAccLimits()
 
-    @abstractmethod
-    def setAccLimits(self):
-        pass
-
-    def getIndexedJointInfo(self):
-        indexedJointInfo = {}
-        for i in range(p.getNumJoints(self.robot)):
-            jointInfo = p.getJointInfo(self.robot, i)
-            indexedJointInfo[jointInfo[0]] = jointInfo[1]
-        return indexedJointInfo
-
-    def getLimits(self):
-        return (self._limitPos_j, self._limitVel_j, self._limitTor_j)
-
-    def getTorqueSpaces(self):
-        ospace = self.getObservationSpace()
-        uu = self._limitTor_j[1, :]
-        ul = self._limitTor_j[0, :]
-        aspace = gym.spaces.Box(low=ul, high=uu, dtype=np.float64)
-        return (ospace, aspace)
-
     def getObservationSpace(self):
         return gym.spaces.Dict({
             'x': gym.spaces.Box(low=self._limitPos_j[0, :], high=self._limitPos_j[1, :], dtype=np.float64), 
             'xdot': gym.spaces.Box(low=self._limitVel_j[0, :], high=self._limitVel_j[1, :], dtype=np.float64), 
         })
-
-    def getVelSpaces(self):
-        ospace = self.getObservationSpace()
-        uu = self._limitVel_j[1, :]
-        ul = self._limitVel_j[0, :]
-        aspace = gym.spaces.Box(low=ul, high=uu, dtype=np.float64)
-        return (ospace, aspace)
-
-    def getAccSpaces(self):
-        ospace = self.getObservationSpace()
-        uu = self._limitAcc_j[1, :]
-        ul = self._limitAcc_j[0, :]
-        aspace = gym.spaces.Box(low=ul, high=uu, dtype=np.float64)
-        return (ospace, aspace)
-
-    def disableVelocityControl(self):
-        self._friction = 0.0
-        for i in range(self._n):
-            p.setJointMotorControl2(
-                self.robot,
-                jointIndex=self.robot_joints[i],
-                controlMode=p.VELOCITY_CONTROL,
-                force=self._friction,
-            )
-
-    def get_ids(self):
-        return self.robot
 
     def apply_torque_action(self, torques):
         for i in range(self._n):
@@ -152,18 +96,3 @@ class AbstractRobot(ABC):
 
         # Concatenate position, orientation, velocity
         self.state = {'x': joint_pos, 'xdot': joint_vel}
-
-    def updateSensing(self):
-        self.sensor_observation = {}
-        for sensor in self._sensors:
-            self.sensor_observation[sensor.name()] = sensor.sense(self.robot)
-
-    def get_observation(self):
-        self.updateState()
-        self.updateSensing()
-        return {**self.state, **self.sensor_observation}
-
-    def addSensor(self, sensor):
-        self._sensors.append(sensor)
-        return sensor.getOSpaceSize()
-

--- a/urdfCommon/urdfEnv.py
+++ b/urdfCommon/urdfEnv.py
@@ -75,7 +75,6 @@ class UrdfEnv(gym.Env):
 
     def _get_ob(self):
         observation = self.robot.get_observation()
-        __import__('pdb').set_trace()
         if not self.observation_space.contains(observation):
             __import__('pdb').set_trace()
             raise WrongObservationError("The observation does not fit the defined observation space")
@@ -98,10 +97,9 @@ class UrdfEnv(gym.Env):
 
     def addSensor(self, sensor):
         self.robot.addSensor(sensor)
-        self.observation_space = gym.spaces.Dict({
-            "jointStates": self.observation_space,
-            "sensor1": gym.spaces.Box(-10, 10, shape=(sensor.getOSpaceSize(), )),
-        })
+        curDict = dict(self.observation_space.spaces)
+        curDict[sensor.name()] = sensor.getObservationSpace()
+        self.observation_space = gym.spaces.Dict(curDict)
 
     def seed(self, seed=None):
         self.np_random, seed = gym.utils.seeding.np_random(seed)

--- a/urdfCommon/urdfEnv.py
+++ b/urdfCommon/urdfEnv.py
@@ -2,6 +2,7 @@ import gym
 import time
 import numpy as np
 import pybullet as p
+import warnings
 
 from abc import abstractmethod
 from urdfCommon.plane import Plane
@@ -90,7 +91,8 @@ class UrdfEnv(gym.Env):
     def _get_ob(self):
         observation = self.robot.get_observation()
         if not self.observation_space.contains(observation):
-            raise WrongObservationError("The observation does not fit the defined observation space", observation, self.observation_space)
+            err = WrongObservationError("The observation does not fit the defined observation space", observation, self.observation_space)
+            warnings.warn(str(err))
         return observation
 
     def addObstacle(self, obst):

--- a/urdfCommon/urdfEnv.py
+++ b/urdfCommon/urdfEnv.py
@@ -7,6 +7,10 @@ from abc import abstractmethod
 from urdfCommon.plane import Plane
 
 
+class WrongObservationError(Exception):
+    pass
+
+
 class UrdfEnv(gym.Env):
     metadata = {"render.modes": ["human"]}
 
@@ -57,7 +61,7 @@ class UrdfEnv(gym.Env):
         for goal in self._goals:
             goal.updateBulletPosition(p, t=self.t())
         p.stepSimulation()
-        ob = self.robot.get_observation()
+        ob = self._get_ob()
 
         # Done by running off boundaries
         reward = 1.0
@@ -68,6 +72,14 @@ class UrdfEnv(gym.Env):
         if self._render:
             self.render()
         return ob, reward, self.done, {}
+
+    def _get_ob(self):
+        observation = self.robot.get_observation()
+        __import__('pdb').set_trace()
+        if not self.observation_space.contains(observation):
+            __import__('pdb').set_trace()
+            raise WrongObservationError("The observation does not fit the defined observation space")
+        return observation
 
     def addObstacle(self, obst):
         self._obsts.append(obst)

--- a/urdfCommon/urdfEnv.py
+++ b/urdfCommon/urdfEnv.py
@@ -8,7 +8,21 @@ from urdfCommon.plane import Plane
 
 
 class WrongObservationError(Exception):
-    pass
+    def __init__(self, msg, observation, observationSpace):
+        msgExt = self.getWrongObservation(observation, observationSpace)
+        super().__init__(msg + msgExt)
+
+    def getWrongObservation(self, o, os):
+        msgExt = ": "
+        for key in o.keys():
+            if not os[key].contains(o[key]):
+                msgExt += "Error in " + key
+                for i, val in enumerate(o[key]):
+                    if val < os[key].low[i]:
+                        msgExt += f"[{i}]: {val} < {os[key].low[i]}"
+                    elif val > os[key].high[i]:
+                        msgExt += f"[{i}]: {val} > {os[key].high[i]}"
+        return msgExt
 
 
 class UrdfEnv(gym.Env):
@@ -76,8 +90,7 @@ class UrdfEnv(gym.Env):
     def _get_ob(self):
         observation = self.robot.get_observation()
         if not self.observation_space.contains(observation):
-            __import__('pdb').set_trace()
-            raise WrongObservationError("The observation does not fit the defined observation space")
+            raise WrongObservationError("The observation does not fit the defined observation space", observation, self.observation_space)
         return observation
 
     def addObstacle(self, obst):

--- a/urdfGymExamples/albert.py
+++ b/urdfGymExamples/albert.py
@@ -13,9 +13,8 @@ def main():
     n_episodes = 1
     n_steps = 100000
     cumReward = 0.0
-    pos0 = np.zeros(10)
     for e in range(n_episodes):
-        ob = env.reset(pos=pos0)
+        ob = env.reset()
         env.setWalls(limits=[[-4, -4], [4, 4]])
         print("Starting episode")
         for i in range(n_steps):

--- a/urdfGymExamples/albert.py
+++ b/urdfGymExamples/albert.py
@@ -1,13 +1,14 @@
 import gym
 import albertReacher
 import numpy as np
+import warnings
 
 
 def main():
     env = gym.make('albert-reacher-vel-v0', dt=0.01, render=True)
     #env = gym.make('albert-v0', dt=0.01, render=True)
     defaultAction = np.zeros(9)
-    defaultAction[0] = 0.0
+    defaultAction[0] = 2.0
     defaultAction[1] = 0.0
     defaultAction[5] = -0.0
     n_episodes = 1
@@ -15,7 +16,6 @@ def main():
     cumReward = 0.0
     for e in range(n_episodes):
         ob = env.reset()
-        env.setWalls(limits=[[-4, -4], [4, 4]])
         print("Starting episode")
         for i in range(n_steps):
             action = env.action_space.sample()
@@ -25,4 +25,8 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    showWarnings = False
+    warningFlag = 'default' if showWarnings else 'ignore'
+    with warnings.catch_warnings():
+        warnings.filterwarnings(warningFlag)
+        main()

--- a/urdfGymExamples/keyboard_input_example.py
+++ b/urdfGymExamples/keyboard_input_example.py
@@ -11,9 +11,7 @@ def main(conn):
     # copy of examples/tiago.py
     env = gym.make("tiago-reacher-vel-v0", dt=0.05, render=True)
     n_steps = 1000
-    pos0 = np.zeros(20)
-    vel0 = np.zeros(19)
-    ob = env.reset(pos=pos0, vel=vel0)
+    ob = env.reset()
 
     # create zero input action
     action = np.zeros(env.n())

--- a/urdfGymExamples/panda_reacher.py
+++ b/urdfGymExamples/panda_reacher.py
@@ -8,7 +8,7 @@ obstacles = False
 
 def main():
     gripper = True
-    env = gym.make('panda-reacher-acc-v0', dt=0.01, render=True, gripper=gripper)
+    env = gym.make('panda-reacher-vel-v0', dt=0.01, render=True, gripper=gripper)
     defaultAction = np.ones(9) * 0.0
     n_episodes = 1
     n_steps = 100000
@@ -23,19 +23,18 @@ def main():
             env.addObstacle(dynamicSphereObst2)
         print("Starting episode")
         for i in range(n_steps):
-            if (int(i/100))%2 == 0:
-                defaultAction[7] = -1.0
-                defaultAction[8] = -1.0
+            if (int(i/70))%2 == 0:
+                defaultAction[7] = -0.02
+                defaultAction[8] = -0.02
             else:
-                defaultAction[7] = 1.0
-                defaultAction[8] = 1.0
+                defaultAction[7] = 0.02
+                defaultAction[8] = 0.02
             action = env.action_space.sample()
             if gripper:
                 action = defaultAction[0:9]
             else:
                 action = defaultAction[0:7]
             ob, reward, done, info = env.step(action)
-            #print(ob[8])
             cumReward += reward
 
 

--- a/urdfGymExamples/tiago.py
+++ b/urdfGymExamples/tiago.py
@@ -5,9 +5,9 @@ import numpy as np
 
 
 def main():
-    env = gym.make('tiago-reacher-vel-v0', dt=0.01, render=True)
+    env = gym.make('tiago-reacher-acc-v0', dt=0.01, render=True)
     defaultAction = np.zeros(env.n())
-    defaultAction[0:2] = np.array([1.0, 0.00])
+    defaultAction[0:2] = np.array([0.0, 0.00])
     defaultAction[10] = 0.0
     n_episodes = 1
     n_steps = 1000
@@ -16,11 +16,11 @@ def main():
     # base
     pos0[0:3] = np.array([0.0, 1.0, -1.0])
     # torso
-    pos0[3] = 0.0
+    pos0[3] = 0.1
     # head
     pos0[4:6] = np.array([1.0, 0.0])
     # left arm
-    pos0[6:13] = np.array([0.0, 0.0, 0.2, 0.0, 0.0, 0.1, -0.1])
+    pos0[6:13] = np.array([0.0, 0.7, 0.2, 0.0, 0.0, 0.1, -0.1])
     # right arm
     pos0[13:20] = np.array([-0.5, 0.2, 0.2, 0.0, 0.0, 0.1, -0.1])
     vel0 = np.zeros(19)
@@ -28,11 +28,11 @@ def main():
     vel0[5:12] = np.array([0.1, 0.1, 0.2, -0.1, 0.1, 0.2, 0.0])
     for e in range(n_episodes):
         ob = env.reset(pos=pos0, vel=vel0)
-        print("base: ", ob[0:3])
-        print("torso: ", ob[3])
-        print("head: ", ob[4:6])
-        print("left arm: ", ob[6:13])
-        print("right arm: ", ob[13:20])
+        print("base: ", ob['x'][0:3])
+        print("torso: ", ob['x'][3])
+        print("head: ", ob['x'][4:6])
+        print("left arm: ", ob['x'][6:13])
+        print("right arm: ", ob['x'][13:20])
         print("Starting episode")
         for i in range(n_steps):
             ob, reward, done, info = env.step(defaultAction)


### PR DESCRIPTION
Changes the observation space from simple NumPy arrays to dictionaries.
This simplifies accessing the joint states and sensor measurements.

Example
```python3
ob, _, _, _ = env.step(action)
print(ob['x']) # prints joint positions
print(ob['xdot']) # prints joint velocities
```

In the case of differential drive robots, the forward and rotational velocity can be accessed through 
```python3
print(ob['vel'])
```

In the process, the diffDriveRobot-class was introduced to avoid copying between boxer, albert, and tiago robot.
Also, the observation spaces were changed to `gym.spaces.Dict` to match the observation.
At last, the observations are checked when before returned. When a observation exceeds limits, an error is thrown (#32)