### PR TITLE
Add robot rotation to LiDAR ray calculation

### DIFF
--- a/urdfenvs/sensors/lidar.py
+++ b/urdfenvs/sensors/lidar.py
@@ -56,9 +56,12 @@ class Lidar(Sensor):
         link_state = p.getLinkState(robot, self._link_id)
         lidar_position = link_state[0]
         ray_start = lidar_position
+        # Alpha and gamma both are the angle of the robot rotated along the z-axis.
+        alpha = np.arcsin(link_state[1][2]) * 2
+        gamma = np.arccos(link_state[1][3]) * 2
         for i, theta in enumerate(self._thetas):
             ray_end = np.array(ray_start) + self._ray_length * np.array(
-                [np.cos(theta), np.sin(theta), 0.0]
+                [np.cos(theta + alpha), np.sin(theta + gamma), 0.0]
             )
             lidar = p.rayTest(ray_start, ray_end)
             self._rel_positions[2 * i : 2 * i + 2] = (


### PR DESCRIPTION
By calculating the angle of rotation along the z-axis from the ``link_state`` and using it in the calculation of ``ray_end``, it seems to solve issue: #102.