### PR TITLE
Set default visual shape id to -1 to prevent pybullet  using older id

### DIFF
--- a/urdfenvs/urdfCommon/urdf_env.py
+++ b/urdfenvs/urdfCommon/urdf_env.py
@@ -402,7 +402,7 @@ class UrdfEnv(gym.Env):
             p.createMultiBody(
                 baseMass=mass,
                 baseCollisionShapeIndex=shape_id,
-                baseVisualShapeIndex=shape_id,
+                baseVisualShapeIndex=-1,
                 basePosition=[pose[0], pose[1], place_height],
                 baseOrientation=p.getQuaternionFromEuler([0, 0, pose[2]]),
             )


### PR DESCRIPTION
Setting the default value of ``baseVisualShapeIndex`` to ``-1``, prevents Pybullet from using the incorrect ID if an attribute is previously added with only a collision shape index, as described in issue #113.