### PR TITLE
Fixes wrong lateral friction for differential drive

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,12 +1,10 @@
 name: Pylint
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - develop
+      - master
 
 jobs:
   build:

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -4,12 +4,10 @@ name: Testing urdf environments
 
 # Controls when the workflow will run
 on: 
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - develop
+      - master
 
 jobs:
   basic:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "urdfenvs"
-version = "0.4.0"
+version = "0.4.1"
 description = "Simple simulation environment for robots, based on the urdf files."
 authors = ["Max Spahn <m.spahn@tudelft.nl>"]
 maintainers = [

--- a/urdfenvs/robots/jackal/jackal.urdf
+++ b/urdfenvs/robots/jackal/jackal.urdf
@@ -39,14 +39,14 @@
       <inertia ixx="0.0013" ixy="0" ixz="0" iyy="0.0024" iyz="0" izz="0.0013"/>
     </inertial>
   </link>
-  <joint name="front_left_wheel_castor" type="continuous">
+  <joint name="front_left_wheel" type="continuous">
     <parent link="chassis_link"/>
     <child link="front_left_wheel_link"/>
     <origin rpy="0 0 0" xyz="0.131 0.187795 0.0345"/>
     <axis xyz="0 1 0"/>
+    <limit effort="10000" velocity="1000"/>
+    <dynamics damping="1.0"/>
   </joint>
-  <!-- In reality, Jackal has only two motors, one per side. However, it's more
-         straightforward for Gazebo to simulate as if there's an actuator per wheel. -->
   <link name="front_right_wheel_link">
     <visual>
       <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
@@ -67,11 +67,13 @@
       <inertia ixx="0.0013" ixy="0" ixz="0" iyy="0.0024" iyz="0" izz="0.0013"/>
     </inertial>
   </link>
-  <joint name="front_right_wheel_castor" type="continuous">
+  <joint name="front_right_wheel" type="continuous">
     <parent link="chassis_link"/>
     <child link="front_right_wheel_link"/>
     <origin rpy="0 0 0" xyz="0.131 -0.187795 0.0345"/>
     <axis xyz="0 1 0"/>
+    <limit effort="10000" velocity="1000"/>
+    <dynamics damping="1.0"/>
   </joint>
   <!-- In reality, Jackal has only two motors, one per side. However, it's more
          straightforward for Gazebo to simulate as if there's an actuator per wheel. -->

--- a/urdfenvs/robots/jackal/jackal.urdf
+++ b/urdfenvs/robots/jackal/jackal.urdf
@@ -91,7 +91,7 @@
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
-      <mass value="100.477"/>
+      <mass value="0.477"/>
       <inertia ixx="0.0013" ixy="0" ixz="0" iyy="0.0024" iyz="0" izz="0.0013"/>
     </inertial>
   </link>
@@ -121,7 +121,7 @@
     </collision>
     <inertial>
       <origin rpy="0 0 0" xyz="0 0 0"/>
-      <mass value="100.477"/>
+      <mass value="0.477"/>
       <inertia ixx="0.0013" ixy="0" ixz="0" iyy="0.0024" iyz="0" izz="0.0013"/>
     </inertial>
   </link>
@@ -158,7 +158,7 @@
     <inertial>
       <!-- Center of mass -->
       <origin rpy="0 0 0" xyz="0.012  0.002 0.067"/>
-      <mass value="10006.523"/>
+      <mass value="6.523"/>
       <!-- Moments of inertia: ( chassis without wheels ) -->
       <inertia ixx="0.3136" ixy="-0.0008" ixz="0.0164" iyy="0.3922" iyz="-0.0009" izz="0.4485"/>
     </inertial>

--- a/urdfenvs/robots/jackal/jackal_robot.py
+++ b/urdfenvs/robots/jackal/jackal_robot.py
@@ -7,12 +7,17 @@ class JackalRobot(DifferentialDriveRobot):
     def __init__(self, mode: str):
         n = 2
         urdf_file = os.path.join(os.path.dirname(__file__), "jackal.urdf")
-        super().__init__(n, urdf_file, mode)
+        super().__init__(n, urdf_file, mode, number_actuated_axes=2)
         self._wheel_radius = 0.098
         self._wheel_distance = 2 * 0.187795 + 0.08
 
     def set_joint_names(self):
-        wheel_joint_names = ["rear_right_wheel", "rear_left_wheel"]
+        wheel_joint_names = [
+            "rear_right_wheel",
+            "rear_left_wheel",
+            "front_right_wheel",
+            "front_left_wheel"
+        ]
         self._joint_names = (
             wheel_joint_names
         )

--- a/urdfenvs/urdf_common/differential_drive_robot.py
+++ b/urdfenvs/urdf_common/differential_drive_robot.py
@@ -21,11 +21,12 @@ class DifferentialDriveRobot(GenericRobot):
         observation with that position.
     """
 
-    def __init__(self, n: int, urdf_file: str, mode: str):
+    def __init__(self, n: int, urdf_file: str, mode: str, number_actuated_axes: int=1):
         """Constructor for differential drive robots."""
         super().__init__(n, urdf_file, mode)
         self._wheel_radius: float = None
         self._wheel_distance: float = None
+        self._number_actuated_axes: int = number_actuated_axes
         self._spawn_offset: np.ndarray = np.array([0.0, 0.0, 0.15])
 
 
@@ -204,13 +205,14 @@ ignored for differential drive robots."
 
     def apply_velocity_action_wheels(self, vels: np.ndarray) -> None:
         """Applies angular velocities to the wheels."""
-        for i in range(2):
-            p.setJointMotorControl2(
-                self._robot,
-                self._robot_joints[i],
-                controlMode=p.VELOCITY_CONTROL,
-                targetVelocity=vels[i],
-            )
+        for axis in range(self._number_actuated_axes):
+            for i in range(2):
+                p.setJointMotorControl2(
+                    self._robot,
+                    self._robot_joints[axis * 2 + i],
+                    controlMode=p.VELOCITY_CONTROL,
+                    targetVelocity=vels[i],
+                )
 
     def apply_base_velocity(self, vels: np.ndarray) -> None:
         """Applies forward and angular velocity to the base.

--- a/urdfenvs/urdf_common/differential_drive_robot.py
+++ b/urdfenvs/urdf_common/differential_drive_robot.py
@@ -87,6 +87,8 @@ ignored for differential drive robots."
                 controlMode=p.VELOCITY_CONTROL,
                 force=0.0,
             )
+        for i in self._castor_joints:
+            p.changeDynamics(self._robot, i, lateralFriction=0)
         for i in range(2, self._n):
             p.resetJointState(
                 self._robot,


### PR DESCRIPTION
Some users pointed out that the differential drives were not moving in perfect circles when given a constant (turning) velocity command. The problem was related to fricton of the castor wheels.

This PR fixes this for the differential drives. To be investigated whether action needs to be taken for the bicycle model.