### PR TITLE
Fix flatten observation

### DIFF
--- a/examples/panda_reacher.py
+++ b/examples/panda_reacher.py
@@ -1,27 +1,24 @@
 import gym
-from urdfenvs.robots.generic_urdf import GenericUrdfReacher
 import numpy as np
+from urdfenvs.robots.generic_urdf import GenericUrdfReacher
+from urdfenvs.scene_examples.goal import dynamicGoal
+from urdfenvs.scene_examples.obstacles import dynamicSphereObst2
+from urdfenvs.urdf_common.urdf_env import UrdfEnv
 
 def run_panda(n_steps=1000, render=False, goal=True, obstacles=True):
-    gripper = True
     robots = [
         GenericUrdfReacher(urdf="panda_with_gripper.urdf", mode="vel"),
     ]
-    env = gym.make(
+    env: UrdfEnv = gym.make(
         "urdf-env-v0",
         dt=0.01, robots=robots, render=render
     )
-    action = np.ones(env.n()) * 0.0
+    env.add_goal(dynamicGoal)
+    env.add_obstacle(dynamicSphereObst2)
+    env.set_spaces()
+    action = np.ones(env.n()) * 0.1
     ob = env.reset()
     print(f"Initial observation : {ob}")
-    if goal:
-        from urdfenvs.scene_examples.goal import dynamicGoal
-        env.add_goal(dynamicGoal)
-
-    if obstacles:
-        from urdfenvs.scene_examples.obstacles import dynamicSphereObst2
-
-        env.add_obstacle(dynamicSphereObst2)
     print("Starting episode")
     history = []
     for i in range(n_steps):
@@ -31,10 +28,7 @@ def run_panda(n_steps=1000, render=False, goal=True, obstacles=True):
         else:
             action[7] = 0.02
             action[8] = 0.02
-        if gripper:
-            ob, _, _, _ = env.step(action)
-        else:
-            ob, _, _, _ = env.step(action[0:7])
+        ob, _, _, _ = env.step(action)
         history.append(ob)
     env.close()
     return history

--- a/examples/panda_reacher.py
+++ b/examples/panda_reacher.py
@@ -11,7 +11,9 @@ def run_panda(n_steps=1000, render=False, goal=True, obstacles=True):
     ]
     env: UrdfEnv = gym.make(
         "urdf-env-v0",
-        dt=0.01, robots=robots, render=render
+        dt=0.01, robots=robots,
+        render=render,
+        observation_checking=False,
     )
     env.add_goal(dynamicGoal)
     env.add_obstacle(dynamicSphereObst2)

--- a/examples/point_robot_lidar_sensor.py
+++ b/examples/point_robot_lidar_sensor.py
@@ -10,6 +10,7 @@ from urdfenvs.scene_examples.obstacles import (
 
 from urdfenvs.robots.generic_urdf import GenericUrdfReacher
 from urdfenvs.sensors.lidar import Lidar
+from urdfenvs.urdf_common.urdf_env import UrdfEnv
 
 
 def run_point_robot_with_lidar(
@@ -18,17 +19,7 @@ def run_point_robot_with_lidar(
     robots = [
         GenericUrdfReacher(urdf="pointRobot.urdf", mode="vel"),
     ]
-    env: urdfenvs.urdf = gym.make("urdf-env-v0", dt=0.01, robots=robots, render=render)
-    action = np.array([0.1, -0.2, 0.0])
-    pos0 = np.array([1.0, 0.1, 0.0])
-    vel0 = np.array([1.0, 0.0, 0.0])
-    number_lidar_rays = 64
-    lidar = Lidar(4, nb_rays=number_lidar_rays, raw_data=False)
-    ob = env.reset(pos=pos0, vel=vel0)
-    env.add_sensor(lidar, robot_ids=[0])
-    # Setup for showing LiDAR detections
-    body_ids = None
-    print(f"Initial observation : {ob}")
+    env: UrdfEnv = gym.make("urdf-env-v0", dt=0.01, robots=robots, render=render)
     for wall in wall_obstacles:
         env.add_obstacle(wall)
     if obstacles:
@@ -36,11 +27,22 @@ def run_point_robot_with_lidar(
         env.add_obstacle(sphereObst2)
         env.add_obstacle(urdfObst1)
         env.add_obstacle(dynamicSphereObst3)
+    number_lidar_rays = 64
+    lidar = Lidar(4, nb_rays=number_lidar_rays, raw_data=False)
+    env.add_sensor(lidar, robot_ids=[0])
+    env.set_spaces()
+
+    action = np.array([0.1, -0.2, 0.0])
+    pos0 = np.array([1.0, 0.1, 0.0])
+    vel0 = np.array([1.0, 0.0, 0.0])
+    ob = env.reset(pos=pos0, vel=vel0)
+    # Setup for showing LiDAR detections
+    print(f"Initial observation : {ob}")
     history = []
     for _ in range(n_steps):
         ob, _, _, _ = env.step(action)
         # Access the lidar observation
-        _ = ob["robot_0"]["LidarSensor"]
+        #_ = ob["robot_0"]["LidarSensor"]
 
         history.append(ob)
     env.close()

--- a/examples/point_robot_obstacle_sensor.py
+++ b/examples/point_robot_obstacle_sensor.py
@@ -31,6 +31,7 @@ def run_point_robot_with_obstacle_sensor(n_steps=1000, render=False, obstacles=T
     # add sensor
     sensor = ObstacleSensor()
     env.add_sensor(sensor, [0])
+    env.set_spaces()
 
     history = []
     for _ in range(n_steps):

--- a/examples/tiago.py
+++ b/examples/tiago.py
@@ -46,7 +46,7 @@ def run_tiago(n_steps=1000, render=False, goal=True, obstacles=True):
     action[0:2] = np.array([0.2, 0.02])
     action[5] = 0.0 # left arm shoulder
     action[14] = 0.0 # right arm shoulder
-    action[22] = 0.5 # finger joint
+    action[22] = 0.01 # finger joint
     vel0 = np.zeros(env.n())
     ob = env.reset()
     print("base: ", ob['robot_0']["joint_state"]["position"][0:3])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "urdfenvs"
-version = "0.6.1"
+version = "0.7.0"
 description = "Simple simulation environment for robots, based on the urdf files."
 authors = ["Max Spahn <m.spahn@tudelft.nl>"]
 maintainers = [

--- a/tests/test_full_sensor.py
+++ b/tests/test_full_sensor.py
@@ -6,13 +6,14 @@ from urdfenvs.sensors.full_sensor import FullSensor
 from urdfenvs.scene_examples.obstacles import sphereObst1, dynamicSphereObst3
 from urdfenvs.scene_examples.goal import goal1
 from urdfenvs.robots.generic_urdf import GenericUrdfReacher
+from urdfenvs.urdf_common.urdf_env import UrdfEnv
 
 
 def test_full_sensor():
     robots = [
         GenericUrdfReacher(urdf="pointRobot.urdf", mode="vel"),
     ]
-    env = gym.make(
+    env: UrdfEnv = gym.make(
         "urdf-env-v0",
         dt=0.01, robots=robots, render=False
     )
@@ -22,58 +23,60 @@ def test_full_sensor():
     env.add_obstacle(dynamicSphereObst3)
     sensor = FullSensor(
         goal_mask=['position', 'is_primary_goal'],
-        obstacle_mask=['velocity', 'position', 'radius']
+        obstacle_mask=['velocity', 'position', 'size'],
+        variance=0.0,
     )
     env.add_sensor(sensor, [0])
     env.add_goal(goal1)
+    env.set_spaces()
     action = np.random.random(env.n())
     for _ in range(10):
         ob, _, _, _ = env.step(action)
     full_sensor_ob = ob['robot_0']['FullSensor']
     assert "obstacles" in full_sensor_ob.keys()
     assert "goals" in full_sensor_ob
-    assert isinstance(full_sensor_ob["obstacles"], list)
-    assert isinstance(full_sensor_ob["obstacles"][0], list)
-    assert isinstance(full_sensor_ob["obstacles"][0][0], np.ndarray)
-    assert isinstance(full_sensor_ob["goals"], list)
-    assert isinstance(full_sensor_ob["goals"][0][0], np.ndarray)
+    assert isinstance(full_sensor_ob["obstacles"], dict)
+    assert isinstance(full_sensor_ob["obstacles"][2], dict)
+    assert isinstance(full_sensor_ob["obstacles"][2]['position'], np.ndarray)
+    assert isinstance(full_sensor_ob["goals"], dict)
+    assert isinstance(full_sensor_ob["goals"][4]['position'], np.ndarray)
     np.testing.assert_array_almost_equal(
-        full_sensor_ob["obstacles"][0][0],
+        full_sensor_ob["obstacles"][2]['velocity'],
         sphereObst1.velocity(t=env.t()),
         decimal=4,
     )
     np.testing.assert_array_almost_equal(
-        full_sensor_ob["obstacles"][0][1],
+        full_sensor_ob["obstacles"][2]['position'],
         sphereObst1.position(t=env.t()),
         decimal=4,
     )
     np.testing.assert_array_almost_equal(
-        full_sensor_ob["goals"][0][0],
+        full_sensor_ob["goals"][4]['position'],
         goal1.position(t=env.t()),
         decimal=4,
     )
     np.testing.assert_array_almost_equal(
-        full_sensor_ob["goals"][0][1],
+        full_sensor_ob["goals"][4]['is_primary_goal'],
         goal1.is_primary_goal(),
         decimal=4,
     )
     np.testing.assert_array_almost_equal(
-        full_sensor_ob["obstacles"][0][2],
+        full_sensor_ob["obstacles"][2]['size'],
         sphereObst1.radius(),
         decimal=4,
     )
     np.testing.assert_array_almost_equal(
-        full_sensor_ob["obstacles"][1][0],
+        full_sensor_ob["obstacles"][3]['velocity'],
         dynamicSphereObst3.velocity(t=env.t()),
         decimal=4,
     )
     np.testing.assert_array_almost_equal(
-        full_sensor_ob["obstacles"][1][1],
+        full_sensor_ob["obstacles"][3]['position'],
         dynamicSphereObst3.position(t=env.t()),
         decimal=4,
     )
     np.testing.assert_array_almost_equal(
-        full_sensor_ob["obstacles"][1][2],
+        full_sensor_ob["obstacles"][3]['size'],
         dynamicSphereObst3.radius(),
         decimal=2,
     )

--- a/tests/test_lidary_sensor.py
+++ b/tests/test_lidary_sensor.py
@@ -22,6 +22,7 @@ def test_full_sensor():
     env.add_obstacle(dynamicSphereObst3)
     sensor = Lidar(4)
     env.add_sensor(sensor, [0])
+    env.set_spaces()
     action = np.random.random(env.n())
     ob, _, _, _ = env.step(action)
     lidar_sensor_ob = ob['robot_0']['LidarSensor']

--- a/tests/test_obstacle_sensor.py
+++ b/tests/test_obstacle_sensor.py
@@ -19,6 +19,7 @@ def test_static_obstacle():
     env.add_obstacle(sphereObst1)
     sensor = ObstacleSensor()
     env.add_sensor(sensor, [0])
+    env.set_spaces()
     action = np.random.random(env.n())
     ob, _, _, _ = env.step(action)
     ob = ob['robot_0']['ObstacleSensor']
@@ -49,6 +50,7 @@ def test_dynamicObstacle():
     env.add_obstacle(dynamicSphereObst3)
     sensor = ObstacleSensor()
     env.add_sensor(sensor, [0])
+    env.set_spaces()
     action = np.random.random(env.n())
     ob, _, _, _ = env.step(action)
     ob = ob['robot_0']['ObstacleSensor']
@@ -78,6 +80,7 @@ def test_shape_observation_space():
     env.add_obstacle(dynamicSphereObst3)
     sensor = ObstacleSensor()
     env.add_sensor(sensor, [0])
+    env.set_spaces()
     action = np.random.random(env.n())
     ob, _, _, _ = env.step(action)
     ob = ob['robot_0']['ObstacleSensor']

--- a/tests/test_vel_envs.py
+++ b/tests/test_vel_envs.py
@@ -147,7 +147,7 @@ def test_allDifferentialDrive(allDifferentialDriveEnvs):
     for setup in allDifferentialDriveEnvs:
         env = gym.make("urdf-env-v0", robots=[setup[0]], render=False, dt=0.01)
         ob = env.reset(pos=setup[1], vel=setup[2])
-        action = np.random.random(env.n()) * 0.1
+        action = np.random.random(env.n()) * 0.02
         np.testing.assert_array_almost_equal(ob['robot_0']['joint_state']['position'], setup[1], decimal=2)
         ob, _, _, _ = env.step(action)
         assert isinstance(ob['robot_0'], dict)

--- a/urdfenvs/sensors/full_sensor.py
+++ b/urdfenvs/sensors/full_sensor.py
@@ -2,11 +2,12 @@ from urdfenvs.sensors.sensor import Sensor
 import numpy as np
 import pybullet as p
 from gym import spaces
-from typing import List
 
 
 class FullSensor(Sensor):
-    def __init__(self, goal_mask: list, obstacle_mask: list, variance: int= 0.1):
+    def __init__(
+        self, goal_mask: list, obstacle_mask: list, variance: int = 0.1
+    ):
         self._obstacle_mask = obstacle_mask
         self._goal_mask = goal_mask
         self._name = "FullSensor"
@@ -23,71 +24,81 @@ class FullSensor(Sensor):
         observation_space_obstacles = {}
         for obst_id, obstacle in obstacles.items():
             observation_space_obstacle = {}
-            if 'position' in self._obstacle_mask:
-                observation_space_obstacle['position'] = spaces.Box(
-                        low=np.array([-5, -5, -5]),
-                        high=np.array([5, 5, 5]),
-                        dtype=np.float32,
+            if "position" in self._obstacle_mask:
+                observation_space_obstacle["position"] = spaces.Box(
+                    low=np.array([-5, -5, -5]),
+                    high=np.array([5, 5, 5]),
+                    dtype=np.float32,
                 )
-            if 'velocity' in self._obstacle_mask:
-                observation_space_obstacle['velocity'] = spaces.Box(
-                        low=np.array([-5, -5, -5]),
-                        high=np.array([5, 5, 5]),
-                        dtype=np.float32,
+            if "velocity" in self._obstacle_mask:
+                observation_space_obstacle["velocity"] = spaces.Box(
+                    low=np.array([-5, -5, -5]),
+                    high=np.array([5, 5, 5]),
+                    dtype=np.float32,
                 )
-            if 'acceleration' in self._obstacle_mask:
-                observation_space_obstacle['acceleration'] = spaces.Box(
-                        low=np.array([-5, -5, -5]),
-                        high=np.array([5, 5, 5]),
-                        dtype=np.float32,
+            if "acceleration" in self._obstacle_mask:
+                observation_space_obstacle["acceleration"] = spaces.Box(
+                    low=np.array([-5, -5, -5]),
+                    high=np.array([5, 5, 5]),
+                    dtype=np.float32,
                 )
-            if 'size' in self._obstacle_mask:
-                low_limit_size = [0, ] * len(obstacle.size())
-                high_limit_size = [5, ] * len(obstacle.size())
-                observation_space_obstacle['size'] = spaces.Box(
-                        low=np.array(low_limit_size),
-                        high=np.array(high_limit_size),
-                        dtype=np.float32,
+            if "size" in self._obstacle_mask:
+                low_limit_size = [
+                    0,
+                ] * len(obstacle.size())
+                high_limit_size = [
+                    5,
+                ] * len(obstacle.size())
+                observation_space_obstacle["size"] = spaces.Box(
+                    low=np.array(low_limit_size),
+                    high=np.array(high_limit_size),
+                    dtype=np.float32,
                 )
-            observation_space_obstacles[obst_id] = spaces.Dict(observation_space_obstacle)
+            observation_space_obstacles[obst_id] = spaces.Dict(
+                observation_space_obstacle
+            )
         if observation_space_obstacles:
-            observation_space['obstacles'] = spaces.Dict(observation_space_obstacles)
+            observation_space["obstacles"] = spaces.Dict(
+                observation_space_obstacles
+            )
         observation_space_goals = {}
         for goal_id, goal in goals.items():
             observation_space_goal = {}
-            if 'position' in self._goal_mask:
-                observation_space_goal['position'] = spaces.Box(
-                        low=np.array([-5, -5, -5]),
-                        high=np.array([5, 5, 5]),
-                        dtype=np.float32,
+            if "position" in self._goal_mask:
+                observation_space_goal["position"] = spaces.Box(
+                    low=np.array([-5, -5, -5]),
+                    high=np.array([5, 5, 5]),
+                    dtype=np.float32,
                 )
-            if 'velocity' in self._goal_mask:
-                observation_space_goal['velocity'] = spaces.Box(
-                        low=np.array([-5, -5, -5]),
-                        high=np.array([5, 5, 5]),
-                        dtype=np.float32,
+            if "velocity" in self._goal_mask:
+                observation_space_goal["velocity"] = spaces.Box(
+                    low=np.array([-5, -5, -5]),
+                    high=np.array([5, 5, 5]),
+                    dtype=np.float32,
                 )
-            if 'acceleration' in self._goal_mask:
-                observation_space_goal['acceleration'] = spaces.Box(
-                        low=np.array([-5, -5, -5]),
-                        high=np.array([5, 5, 5]),
-                        dtype=np.float32,
+            if "acceleration" in self._goal_mask:
+                observation_space_goal["acceleration"] = spaces.Box(
+                    low=np.array([-5, -5, -5]),
+                    high=np.array([5, 5, 5]),
+                    dtype=np.float32,
                 )
-            if 'weight' in self._goal_mask:
-                observation_space_goal['weight'] = spaces.Box(
-                        low=0,
-                        high=10,
-                        dtype=np.float32,
+            if "weight" in self._goal_mask:
+                observation_space_goal["weight"] = spaces.Box(
+                    low=0,
+                    high=10,
+                    dtype=np.float32,
                 )
-            if 'is_primary_goal' in self._goal_mask:
-                observation_space_goal['is_primary_goal'] = spaces.Box(
-                        low=np.array([False], dtype=bool),
-                        high=np.array([True], dtype=bool),
-                        dtype=bool,
+            if "is_primary_goal" in self._goal_mask:
+                observation_space_goal["is_primary_goal"] = spaces.Box(
+                    low=np.array([False], dtype=bool),
+                    high=np.array([True], dtype=bool),
+                    dtype=bool,
                 )
-            observation_space_goals[goal_id] = spaces.Dict(observation_space_goal)
+            observation_space_goals[goal_id] = spaces.Dict(
+                observation_space_goal
+            )
         if observation_space_goals:
-            observation_space['goals'] = spaces.Dict(observation_space_goals)
+            observation_space["goals"] = spaces.Dict(observation_space_goals)
         return spaces.Dict({self._name: spaces.Dict(observation_space)})
 
     def sense(self, robot, obstacles: dict, goals: dict, t: float):
@@ -97,10 +108,10 @@ class FullSensor(Sensor):
         for obst_id, obstacle in obstacles.items():
             observation = {}
             for mask_item in self._obstacle_mask:
-                if mask_item == 'position':
+                if mask_item == "position":
                     value, _ = p.getBasePositionAndOrientation(obst_id)
 
-                elif mask_item == 'velocity':
+                elif mask_item == "velocity":
                     value, _ = p.getBaseVelocity(obst_id)
 
                 else:
@@ -110,9 +121,10 @@ class FullSensor(Sensor):
                         value = getattr(obstacle, mask_item)()
                 if isinstance(value, float):
                     value = [value]
-                observation[mask_item] = np.random.normal(np.array(value), self._noise_variance).astype('float32')
+                observation[mask_item] = np.random.normal(
+                    np.array(value), self._noise_variance
+                ).astype("float32")
             observations[obst_id] = observation
-
 
         if observations:
             sensor_observation["obstacles"] = observations
@@ -121,10 +133,10 @@ class FullSensor(Sensor):
         for obst_id, goal in goals.items():
             observation = {}
             for mask_item in self._goal_mask:
-                if mask_item == 'position':
+                if mask_item == "position":
                     value, _ = p.getBasePositionAndOrientation(obst_id)
 
-                elif mask_item == 'velocity':
+                elif mask_item == "velocity":
                     value, _ = p.getBaseVelocity(obst_id)
 
                 else:
@@ -137,7 +149,9 @@ class FullSensor(Sensor):
                 if isinstance(value, bool):
                     observation[mask_item] = np.array([value])
                 else:
-                    observation[mask_item] = np.random.normal(np.array(value), self._noise_variance).astype('float32')
+                    observation[mask_item] = np.random.normal(
+                        np.array(value), self._noise_variance
+                    ).astype("float32")
             observations[obst_id] = observation
 
         if observations:

--- a/urdfenvs/sensors/full_sensor.py
+++ b/urdfenvs/sensors/full_sensor.py
@@ -18,20 +18,84 @@ class FullSensor(Sensor):
     def observation_size(self) -> tuple:
         return 1, 2
 
-    def get_observation_space(self):
-        return spaces.Box(
-            low=-1.0,
-            high=1.0,
-            shape=self.observation_size(),
-            dtype=np.float64,
-        )
+    def get_observation_space(self, obstacles: dict, goals: dict):
+        observation_space = {}
+        observation_space_obstacles = {}
+        for obst_id, obstacle in obstacles.items():
+            observation_space_obstacle = {}
+            if 'position' in self._obstacle_mask:
+                observation_space_obstacle['position'] = spaces.Box(
+                        low=np.array([-5, -5, -5]),
+                        high=np.array([5, 5, 5]),
+                        dtype=np.float32,
+                )
+            if 'velocity' in self._obstacle_mask:
+                observation_space_obstacle['velocity'] = spaces.Box(
+                        low=np.array([-5, -5, -5]),
+                        high=np.array([5, 5, 5]),
+                        dtype=np.float32,
+                )
+            if 'acceleration' in self._obstacle_mask:
+                observation_space_obstacle['acceleration'] = spaces.Box(
+                        low=np.array([-5, -5, -5]),
+                        high=np.array([5, 5, 5]),
+                        dtype=np.float32,
+                )
+            if 'size' in self._obstacle_mask:
+                low_limit_size = [0, ] * len(obstacle.size())
+                high_limit_size = [5, ] * len(obstacle.size())
+                observation_space_obstacle['size'] = spaces.Box(
+                        low=np.array(low_limit_size),
+                        high=np.array(high_limit_size),
+                        dtype=np.float32,
+                )
+            observation_space_obstacles[obst_id] = spaces.Dict(observation_space_obstacle)
+        if observation_space_obstacles:
+            observation_space['obstacles'] = spaces.Dict(observation_space_obstacles)
+        observation_space_goals = {}
+        for goal_id, goal in goals.items():
+            observation_space_goal = {}
+            if 'position' in self._goal_mask:
+                observation_space_goal['position'] = spaces.Box(
+                        low=np.array([-5, -5, -5]),
+                        high=np.array([5, 5, 5]),
+                        dtype=np.float32,
+                )
+            if 'velocity' in self._goal_mask:
+                observation_space_goal['velocity'] = spaces.Box(
+                        low=np.array([-5, -5, -5]),
+                        high=np.array([5, 5, 5]),
+                        dtype=np.float32,
+                )
+            if 'acceleration' in self._goal_mask:
+                observation_space_goal['acceleration'] = spaces.Box(
+                        low=np.array([-5, -5, -5]),
+                        high=np.array([5, 5, 5]),
+                        dtype=np.float32,
+                )
+            if 'weight' in self._goal_mask:
+                observation_space_goal['weight'] = spaces.Box(
+                        low=0,
+                        high=10,
+                        dtype=np.float32,
+                )
+            if 'is_primary_goal' in self._goal_mask:
+                observation_space_goal['is_primary_goal'] = spaces.Box(
+                        low=np.array([False], dtype=bool),
+                        high=np.array([True], dtype=bool),
+                        dtype=bool,
+                )
+            observation_space_goals[goal_id] = spaces.Dict(observation_space_goal)
+        if observation_space_goals:
+            observation_space['goals'] = spaces.Dict(observation_space_goals)
+        return spaces.Dict({self._name: spaces.Dict(observation_space)})
 
     def sense(self, robot, obstacles: dict, goals: dict, t: float):
-        sensor_observation = {"goals": [], "obstacles": []}
+        sensor_observation = {}
 
-        exact_observations = []
+        observations = {}
         for obst_id, obstacle in obstacles.items():
-            exact_observation = []
+            observation = {}
             for mask_item in self._obstacle_mask:
                 if mask_item == 'position':
                     value, _ = p.getBasePositionAndOrientation(obst_id)
@@ -44,44 +108,39 @@ class FullSensor(Sensor):
                         value = getattr(obstacle, mask_item)(t=t)
                     except TypeError:
                         value = getattr(obstacle, mask_item)()
-                exact_observation.append(np.array(value))
-            exact_observations.append(exact_observation)
-
-        noisy_observations = []
-        for exact_observation in exact_observations:
-            if isinstance(exact_observation, np.ndarray):
-                noisy_observation = np.random.normal(exact_observation, self._noise_variance)
-            else:
-                noisy_observation = exact_observation
-            noisy_observations.append(noisy_observation)
-        sensor_observation["obstacles"] = noisy_observations
+                if isinstance(value, float):
+                    value = [value]
+                observation[mask_item] = np.random.normal(np.array(value), self._noise_variance).astype('float32')
+            observations[obst_id] = observation
 
 
-        exact_observations = []
-        for goal_id, goal in goals.items():
-            exact_observation = []
+        if observations:
+            sensor_observation["obstacles"] = observations
+
+        observations = {}
+        for obst_id, goal in goals.items():
+            observation = {}
             for mask_item in self._goal_mask:
                 if mask_item == 'position':
-                    value, _ = p.getBasePositionAndOrientation(goal_id)
+                    value, _ = p.getBasePositionAndOrientation(obst_id)
 
                 elif mask_item == 'velocity':
-                    value, _ = p.getBaseVelocity(goal_id)
+                    value, _ = p.getBaseVelocity(obst_id)
+
                 else:
                     try:
                         value = getattr(goal, mask_item)(t=t)
                     except TypeError:
                         value = getattr(goal, mask_item)()
-                exact_observation.append(np.array(value))
-            exact_observations.append(exact_observation)
+                if isinstance(value, float):
+                    value = [value]
+                if isinstance(value, bool):
+                    observation[mask_item] = np.array([value])
+                else:
+                    observation[mask_item] = np.random.normal(np.array(value), self._noise_variance).astype('float32')
+            observations[obst_id] = observation
 
-        noisy_observations = []
-        for exact_observation in exact_observations:
-            if isinstance(exact_observation, np.ndarray):
-                noisy_observation = np.random.normal(exact_observation, self._noise_variance)
-            else:
-                noisy_observation = exact_observation
-            noisy_observations.append(noisy_observation)
-
-        sensor_observation["goals"] = noisy_observations
+        if observations:
+            sensor_observation["goals"] = observations
 
         return sensor_observation

--- a/urdfenvs/sensors/lidar.py
+++ b/urdfenvs/sensors/lidar.py
@@ -53,15 +53,16 @@ class Lidar(Sensor):
             return self._nb_rays
         return self._nb_rays * 2
 
-    def get_observation_space(self):
+    def get_observation_space(self, obstacles: dict, goals: dict):
         """Create observation space, all observations should be inside the
         observation space."""
-        return gym.spaces.Box(
-            -self._ray_length,
-            self._ray_length,
+        observation_space = gym.spaces.Box(
+            -self._ray_length-0.01,
+            self._ray_length+0.01,
             shape=(self.get_observation_size(),),
             dtype=np.float64,
         )
+        return gym.spaces.Dict({self._name: observation_space})
 
     def sense(self, robot, obstacles: dict, goals: dict, t: float):
         """Sense the distance toward the next object with the Lidar."""

--- a/urdfenvs/sensors/lidar.py
+++ b/urdfenvs/sensors/lidar.py
@@ -2,7 +2,6 @@
 import numpy as np
 import pybullet as p
 import gym
-from typing import List
 
 from urdfenvs.sensors.sensor import Sensor
 

--- a/urdfenvs/sensors/obstacle_sensor.py
+++ b/urdfenvs/sensors/obstacle_sensor.py
@@ -2,6 +2,7 @@ import numpy as np
 import pybullet as p
 import gym
 from urdfenvs.sensors.sensor import Sensor
+from urdfenvs import __version__
 
 
 class ObstacleSensor(Sensor):
@@ -22,7 +23,6 @@ class ObstacleSensor(Sensor):
         and angular velocity in cartesian format (x, y, z)
 
     """
-
     def __init__(self):
         super().__init__("ObstacleSensor")
         self._observation = np.zeros(self.get_observation_size())
@@ -37,7 +37,7 @@ class ObstacleSensor(Sensor):
             )
         return size
 
-    def get_observation_space(self):
+    def get_observation_space(self, obstacles: dict, goals: dict):
         """
         Create observation space, all observed objects should be inside the
         observation space.
@@ -84,7 +84,7 @@ class ObstacleSensor(Sensor):
                 }
             )
 
-        return spaces_dict
+        return gym.spaces.Dict({self._name: spaces_dict})
 
     def sense(self, robot, *args):
         """

--- a/urdfenvs/sensors/sensor.py
+++ b/urdfenvs/sensors/sensor.py
@@ -21,7 +21,7 @@ class Sensor(object):
         pass
 
     @abstractmethod
-    def get_observation_space(self):
+    def get_observation_space(self, obstacles: dict, goals: dict):
         pass
 
     @abstractmethod

--- a/urdfenvs/urdf_common/bicycle_model.py
+++ b/urdfenvs/urdf_common/bicycle_model.py
@@ -45,7 +45,7 @@ class BicycleModel(GenericRobot):
 ignored for bicycle models."
         )
         if hasattr(self, "_robot"):
-            p.resetSimulation()
+            p.removeBody(self._robot)
         base_orientation = p.getQuaternionFromEuler([0, 0, pos[2]])
         spawn_position = self._spawn_offset
         spawn_position[0:2] += pos[0:2]

--- a/urdfenvs/urdf_common/bicycle_model.py
+++ b/urdfenvs/urdf_common/bicycle_model.py
@@ -125,6 +125,15 @@ ignored for bicycle models."
             }
         )
 
+    def get_velocity_spaces(self) -> tuple:
+        """Get observation space and action space when using velocity
+        control."""
+        ospace = self.get_observation_space()
+        uu = self._limit_vel_forward_j[1, :]
+        ul = self._limit_vel_forward_j[0, :]
+        aspace = gym.spaces.Box(low=ul, high=uu, dtype=np.float64)
+        return (ospace, aspace)
+
     def apply_velocity_action(self, vels: np.ndarray) -> None:
         """Applies velocities to steering and forward motion."""
         p.setJointMotorControl2(

--- a/urdfenvs/urdf_common/differential_drive_robot.py
+++ b/urdfenvs/urdf_common/differential_drive_robot.py
@@ -86,7 +86,7 @@ class DifferentialDriveRobot(GenericRobot):
 ignored for differential drive robots."
         )
         if hasattr(self, "_robot"):
-            p.resetSimulation()
+            p.removeBody(self._robot)
         base_orientation = p.getQuaternionFromEuler([0, 0, self._spawn_rotation + pos[2]])
         spawn_position = self._spawn_offset
         spawn_position[0:2] += pos[0:2]

--- a/urdfenvs/urdf_common/holonomic_robot.py
+++ b/urdfenvs/urdf_common/holonomic_robot.py
@@ -16,7 +16,7 @@ class HolonomicRobot(GenericRobot):
             mount_orientation: np.ndarray,) -> None:
 
         if hasattr(self, "_robot"):
-            p.resetSimulation()
+            p.removeBody(self._robot)
         self._robot = p.loadURDF(
             fileName=self._urdf_file,
             basePosition=mount_position.tolist(),

--- a/urdfenvs/urdf_common/quadrotor.py
+++ b/urdfenvs/urdf_common/quadrotor.py
@@ -166,11 +166,21 @@ ignored for drones."
             }
         )
 
+    def get_velocity_spaces(self) -> tuple:
+        """Get observation space and action space when using velocity
+        control."""
+        ospace = self.get_observation_space()
+        uu = self._limit_rotors_j[1, :]
+        ul = self._limit_rotors_j[0, :]
+        aspace = gym.spaces.Box(low=ul, high=uu, dtype=np.float64)
+        return (ospace, aspace)
+
     def apply_velocity_action(self, vels: np.ndarray) -> None:
         """Applies the propeller speed action to the quadrotor.
         """
         direction = np.array([1, 1, -1, -1])
         for i in range(4):
+
             p.setJointMotorControl2(
                 self._robot,
                 self._robot_joints[i],

--- a/urdfenvs/urdf_common/quadrotor.py
+++ b/urdfenvs/urdf_common/quadrotor.py
@@ -75,7 +75,7 @@ class QuadrotorModel(GenericRobot):
 ignored for drones."
         )
         if hasattr(self, "_robot"):
-            p.resetSimulation()
+            p.removeBody(self._robot)
         base_orientation = pos[3:7]
         spawn_pos = self._spawn_offset + np.array([pos[0], pos[1], pos[2]])
         self._robot = p.loadURDF(

--- a/urdfenvs/urdf_common/urdf_env.py
+++ b/urdfenvs/urdf_common/urdf_env.py
@@ -24,7 +24,6 @@ def check_observation(obs, ob):
             check_observation(obs[key], value)
         elif isinstance(value, np.ndarray):
             if not obs[key].contains(value):
-                breakpoint()
                 s = f"key: {key}: {value} not in {obs[key]}"
                 if np.any(value < obs[key].low):
                     index = np.where(value < obs[key].low)[0]
@@ -46,7 +45,7 @@ class UrdfEnv(gym.Env):
 
     def __init__(
         self, robots: List[GenericRobot],
-        render: bool = False, dt: float = 0.01
+        render: bool = False, dt: float = 0.01, observation_checking = True
     ) -> None:
         """Constructor for environment.
 
@@ -70,6 +69,7 @@ class UrdfEnv(gym.Env):
         self._obsts: dict = {}
         self._goals: dict = {}
         self._space_set = False
+        self._observation_checking = observation_checking
         if self._render:
             self._cid = p.connect(p.GUI)
             p.configureDebugVisualizer(p.COV_ENABLE_GUI, 0)
@@ -182,7 +182,7 @@ class UrdfEnv(gym.Env):
 
             observation[f'robot_{i}'] = obs
         if hasattr(self, 'observation_space'):
-            if not self.observation_space.contains(observation):
+            if not self.observation_space.contains(observation) and self._observation_checking:
                 check_observation(self.observation_space, observation)
 
             """

--- a/urdfenvs/urdf_common/urdf_env.py
+++ b/urdfenvs/urdf_common/urdf_env.py
@@ -18,6 +18,9 @@ from urdfenvs.urdf_common.generic_robot import GenericRobot
 class WrongObservationError(Exception):
     pass
 
+class WrongActionError(Exception):
+    pass
+
 
 def check_observation(obs, ob):
     for key, value in ob.items():
@@ -157,11 +160,15 @@ class UrdfEnv(gym.Env):
             action_space_as_dict[f"robot_{i}"] = action_space_robot_i
 
         self.observation_space = gym.spaces.Dict(observation_space_as_dict)
-        self.action_space = gym.spaces.Dict(action_space_as_dict)
+        action_space = gym.spaces.Dict(action_space_as_dict)
+        self.action_space = gym.spaces.flatten_space(action_space)
 
     def step(self, action):
         self._t += self.dt()
         # Feed action to the robot and get observation of robot's state
+
+        if not self.action_space.contains(action):
+            raise WrongActionError(f"{action} not in {self.action_space}")
 
         action_id = 0
         for robot in self._robots:

--- a/urdfenvs/urdf_common/urdf_env.py
+++ b/urdfenvs/urdf_common/urdf_env.py
@@ -165,8 +165,8 @@ class UrdfEnv(gym.Env):
 
         action_id = 0
         for robot in self._robots:
-            action = action[action_id : action_id + robot.n()]
-            robot.apply_action(action, self.dt())
+            action_robot = action[action_id : action_id + robot.n()]
+            robot.apply_action(action_robot, self.dt())
             action_id += robot.n()
 
         self.update_obstacles()


### PR DESCRIPTION
As the `flatten_observation` did not work as intended, see #170 and #171, this PR makes sure that the `FlattenObservation`-wrapper works and effectively replaces the `flatten_observation` argument.

This required some changes in the structure of `urdf_env.py`.

The new setup for an environment would be

1. Create list of robots as before.
2. Create UrdfEnv with the list of robots and arguments.
3. Add obstacles, goals and sensors.
4. Finalize step 3. by calling the function `env.set_spaces()` which effectively sets action and observation spaces.
5. OPTIONAL: Flatten your observations using the openAI wrapper `env = gym.wrappers.flatten_observation.FlattenObservation(env)`
6. That's it, you can now run your episodes starting with `env.reset()`.

### Bug Fixes

- Fixes too high velocities in test_vel.
- Sets the spaces after the adding of scene objects.

### Ft

- Adds option to ignore observation space violations.

### Ft[sensors]

- Fixes wrong observation spaces for sensors.

### Ft[structure]

- Redefines reset and __init__in urdf_env.
