### PR TITLE
🔧 Fixed the Torque Input Issue for Torque Mode

### DIFF
--- a/urdfenvs/urdf_common/holonomic_robot.py
+++ b/urdfenvs/urdf_common/holonomic_robot.py
@@ -86,9 +86,11 @@ class HolonomicRobot(GenericRobot):
 
     def apply_torque_action(self, torques: np.ndarray) -> None:
         for i in range(self._n):
+            p.setJointMotorControl2(self._robot,
+                jointIndex=self._robot_joints[i],controlMode= p.VELOCITY_CONTROL, force=0.1)
             p.setJointMotorControl2(
                 self._robot,
-                self._robot_joints[i],
+                jointIndex=self._robot_joints[i],
                 controlMode=p.TORQUE_CONTROL,
                 force=torques[i],
             )


### PR DESCRIPTION
I surfed the web and turns out the link you sent in https://github.com/maxspahn/gym_envs_urdf/issues/230#issuecomment-1708340979 had the correct solution. Now robots (I tested point and panda) react to torque input, but it seems that (at least in the case of panda arm) robot falls. By falling I mean that robot can't preserve the initial posture and the links kinda fall to the ground. It reacts to the input torque but with a disfigured position. Is it natural? We don't have this behavior in velocity mode. 

I'd be happy if you test it. 