### PR TITLE
fix error due to visualization id not matching number of visualizations

### DIFF
--- a/urdfenvs/urdf_common/urdf_env.py
+++ b/urdfenvs/urdf_common/urdf_env.py
@@ -340,8 +340,8 @@ class UrdfEnv(gym.Env):
             )
 
     def update_visualizations(self, positions) -> None:
-        for visual_shape_id, info in self._visualizations.items():
-            position = positions[visual_shape_id-1]
+        for i, (visual_shape_id, info) in enumerate(self._visualizations.items()):
+            position = positions[i]
             rotation = [1, 0, 0, 0]
             p.resetBasePositionAndOrientation(
                 visual_shape_id, position, rotation


### PR DESCRIPTION
The previous code resulted in an error when the maximum `visual_shape_id` did not match the size of the `positions` vector.
Now, the i-th position within the `positions` vector are used to update the i-th visualization in `self._visualizations`.