### PR TITLE
Ft mujoco sensors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "urdfenvs"
-version = "0.9.3"
+version = "0.9.4"
 description = "Simple simulation environment for robots, based on the urdf files."
 authors = ["Max Spahn <m.spahn@tudelft.nl>"]
 maintainers = [

--- a/urdfenvs/sensors/free_space_decomposition.py
+++ b/urdfenvs/sensors/free_space_decomposition.py
@@ -1,7 +1,5 @@
 """Module for fsd sensor based on lidar."""
 import numpy as np
-import pybullet as p
-import gymnasium as gym
 
 from urdfenvs.sensors.lidar import Lidar
 from urdfenvs.sensors.fsd_sensor import FSDSensor
@@ -45,7 +43,7 @@ class FreeSpaceDecompositionSensor(FSDSensor, Lidar):
         lidar_observation = Lidar.sense(
             self, robot, obstacles, goals, t
         ).reshape((self._nb_rays, 2))
-        lidar_position = np.array(p.getLinkState(robot, self._link_id)[0])
+        lidar_position = self._physics_engine.get_link_position(robot, self._link_id)
         relative_positions = np.concatenate(
             (
                 np.reshape(lidar_observation, (self._nb_rays, 2)),

--- a/urdfenvs/sensors/free_space_occupancy.py
+++ b/urdfenvs/sensors/free_space_occupancy.py
@@ -1,11 +1,8 @@
 """Module for fsd sensor based on lidar."""
 import numpy as np
-import pybullet as p
-import gymnasium as gym
 
 from urdfenvs.sensors.fsd_sensor import FSDSensor
 from urdfenvs.sensors.occupancy_sensor import OccupancySensor
-from urdfenvs.urdf_common.helpers import extract_link_id
 
 
 class FreeSpaceOccupancySensor(FSDSensor, OccupancySensor):
@@ -22,6 +19,7 @@ class FreeSpaceOccupancySensor(FSDSensor, OccupancySensor):
         plotting_interval: int = -1,
         plotting_interval_fsd: int = -1,
         planar_visualization: bool = False,
+        physics_engine_name: str = 'pybullet',
     ):
         FSDSensor.__init__(
             self,
@@ -38,6 +36,7 @@ class FreeSpaceOccupancySensor(FSDSensor, OccupancySensor):
             interval=interval,
             variance=variance,
             plotting_interval=plotting_interval,
+            physics_engine_name=physics_engine_name
         )
         self._link_name = link_name
         self._name = name
@@ -47,7 +46,7 @@ class FreeSpaceOccupancySensor(FSDSensor, OccupancySensor):
         occupancy = OccupancySensor.sense(
             self, robot, obstacles, goals, t
         ).reshape((-1, 1))
-        link_id = extract_link_id(robot, self._link_name)
-        seed_point = np.array(p.getLinkState(robot, link_id)[0])
+        link_id = self._physics_engine.extract_link_id(robot, self._link_name)
+        seed_point = self._physics_engine.get_link_position(robot, link_id)
         point_positions = self._mesh_flat[np.where(occupancy == 1)[0]]
         return self.compute_fsd(point_positions, seed_point)

--- a/urdfenvs/sensors/fsd_sensor.py
+++ b/urdfenvs/sensors/fsd_sensor.py
@@ -61,11 +61,11 @@ class FSDSensor(Sensor):
 
     def visualize_constraints(self):
         plot_points = self._fsd.get_points()
-        pybullet.removeAllUserDebugItems()
+        self._physics_engine.clear_visualizations()
         for plot_point in plot_points:
             start_point = (plot_point[0, 0], plot_point[-1, 0], self._height)
             end_point = (plot_point[0, 1], plot_point[-1, 1], self._height)
-            pybullet.addUserDebugLine(start_point, end_point)
+            self._physics_engine.add_visualization_line(start_point, end_point)
 
     def visualize_constraints_with_boxes(self, center_position: np.ndarray):
         constraints = self._fsd.constraints()

--- a/urdfenvs/sensors/grid_sensor.py
+++ b/urdfenvs/sensors/grid_sensor.py
@@ -20,9 +20,13 @@ class GridSensor(Sensor):
         name: str = "Grid",
         variance: float = 0.0,
         plotting_interval: int = -1,
+        physics_engine_name: str = "pybullet",
     ):
         super().__init__(
-            name, variance=variance, plotting_interval=plotting_interval
+            name,
+            variance=variance,
+            plotting_interval=plotting_interval,
+            physics_engine_name=physics_engine_name,
         )
         self._resolution = resolution
         self._limits = limits

--- a/urdfenvs/sensors/lidar.py
+++ b/urdfenvs/sensors/lidar.py
@@ -4,7 +4,7 @@ import pybullet as p
 import gymnasium as gym
 
 from urdfenvs.sensors.sensor import Sensor
-from urdfenvs.urdf_common.helpers import add_shape, extract_link_id
+from urdfenvs.urdf_common.helpers import add_shape
 
 
 class Lidar(Sensor):
@@ -87,7 +87,7 @@ class Lidar(Sensor):
         """Sense the distance toward the next object with the Lidar."""
         self._call_counter += 1
         if not self._link_id:
-            self._link_id = extract_link_id(robot, self._link_name)
+            self._link_id = self._physics_engine.extract_link_id(robot, self._link_name)
         link_state = p.getLinkState(robot, self._link_id)
 
         lidar_position = link_state[0]

--- a/urdfenvs/sensors/lidar_3d.py
+++ b/urdfenvs/sensors/lidar_3d.py
@@ -93,24 +93,10 @@ class Lidar3D(Sensor):
         )
         return gym.spaces.Dict({self._name: observation_space})
 
-    def extract_link_id(self, robot):
-        number_links = p.getNumJoints(robot)
-        joint_names = []
-        for i in range(number_links):
-            joint_name = p.getJointInfo(robot, i)[1].decode("UTF-8")
-            joint_names.append(joint_name)
-            if joint_name == self._link_name:
-                self._link_id = i
-                return
-        raise LinkIdNotFoundError(
-            f"Link with name {self._link_name} not found. "
-            f"Possible links are {joint_names}"
-        )
-
     def sense(self, robot, obstacles: dict, goals: dict, t: float):
         """Sense the distance toward the next object with the Lidar."""
         if not self._link_id:
-            self.extract_link_id(robot)
+            self._link_id = self._physics_engine.extract_link_id(robot), self._link_name
         link_state = p.getLinkState(robot, self._link_id)
 
         lidar_position = link_state[0]

--- a/urdfenvs/sensors/occupancy_sensor.py
+++ b/urdfenvs/sensors/occupancy_sensor.py
@@ -17,6 +17,7 @@ class OccupancySensor(GridSensor):
         interval: int = -1,
         variance: float = 0.0,
         plotting_interval: int = -1,
+        physics_engine_name: str = 'pybullet',
     ):
         super().__init__(
             limits=limits,
@@ -25,6 +26,7 @@ class OccupancySensor(GridSensor):
             name="Occupancy",
             variance=variance,
             plotting_interval=plotting_interval,
+            physics_engine_name=physics_engine_name,
         )
         self._voxel_ids = [
             -1,

--- a/urdfenvs/sensors/physics_engine_interface.py
+++ b/urdfenvs/sensors/physics_engine_interface.py
@@ -1,0 +1,105 @@
+"""Physics engine interfaces for sensors."""
+from typing import Tuple, List
+from abc import abstractmethod
+
+import numpy as np
+import pybullet
+
+class LinkIdNotFoundError(Exception):
+    pass
+
+
+class PhysicsEngineInterface():
+    """Physics engine interface for sensors.
+
+    This abstract class defines interfaces that a physics engine must define.
+    """
+
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def get_obstacle_pose(self, *args) -> Tuple[List[float], List[float]]:
+        pass
+
+    @abstractmethod
+    def get_obstacle_velocity(self, *args) -> Tuple[List[float], List[float]]:
+        pass
+
+    @abstractmethod
+    def get_link_position(self, *args) -> np.ndarray:
+        pass
+
+    def clear_visualizations(self) -> None:
+        raise NotImplementedError(
+            f"Clearing of visualization of lines not implemented for {type(self)}."
+        )
+
+    def add_visualization_line(self, *args) -> None:
+        raise NotImplementedError(
+            f"Visualization of lines not implemented for {type(self)}."
+        )
+
+
+class PybulletInterface(PhysicsEngineInterface):
+    """
+    Physics engine interface for bullet.
+    """
+    def extract_link_id(self, robot, link_name: str) -> int:
+        number_links = pybullet.getNumJoints(robot)
+        joint_names = []
+        for i in range(number_links):
+            joint_name = pybullet.getJointInfo(robot, i)[1].decode("UTF-8")
+            joint_names.append(joint_name)
+            if joint_name == link_name:
+                return i
+        raise LinkIdNotFoundError(
+            f"Link with name {link_name} not found. "
+            f"Possible links are {joint_names}"
+        )
+
+
+    def get_obstacle_pose(self, obst_id: int) -> Tuple[List[float], List[float]]:
+        position, orientation = pybullet.getBasePositionAndOrientation(obst_id)
+        return position, orientation
+
+    def get_obstacle_velocity(self, obst_id: int) -> Tuple[List[float], List[float]]:
+        linear, angular = pybullet.getBaseVelocity(obst_id)
+        return linear, angular
+
+    def get_link_position(self, robot, link_id) -> np.ndarray:
+        link_position = np.array(pybullet.getLinkState(robot, link_id)[0])
+        return link_position
+
+    def clear_visualizations(self) -> None:
+        pybullet.removeAllUserDebugItems()
+
+    def add_visualization_line(
+        self, start_point: Tuple[float], end_point: Tuple[float]
+    ) -> None:
+        pybullet.addUserDebugLine(start_point, end_point)
+
+class MujocoInterface(PhysicsEngineInterface):
+    """
+    Physics engine interface for mujoco.
+    """
+    def extract_link_id(self, robot, link_name: str) -> int:
+        return self._data.body(link_name).id
+
+    def set_data(self, data) -> None:
+        """Set pointer to mujoco data to sensor."""
+        self._data = data
+
+    def get_link_position(self, robot, link_id) -> np.ndarray:
+        link_position = self._data.xpos[link_id]
+        return link_position
+
+    def get_obstacle_pose(self, obst_id: int) -> Tuple[List[float], List[float]]:
+        pos = self._data.mocap_pos[obst_id]
+        ori = self._data.mocap_quat[obst_id]
+        return pos.tolist(), ori.tolist()
+
+    def get_obstacle_velocity(self, obst_id: int) -> None:
+        raise NotImplementedError(
+            "Obstacle velocity not implemented for mujoco."
+        )

--- a/urdfenvs/sensors/sdf_sensor.py
+++ b/urdfenvs/sensors/sdf_sensor.py
@@ -18,6 +18,7 @@ class SDFSensor(GridSensor):
         resolution: np.ndarray = np.array([10, 10, 10], dtype=int),
         interval: int = -1,
         variance: float = 0.0,
+        physics_engine_name='pybullet',
     ):
         super().__init__(
             limits=limits,
@@ -25,6 +26,7 @@ class SDFSensor(GridSensor):
             interval=interval,
             name="SDFSensor",
             variance=variance,
+            physics_engine_name=physics_engine_name,
         )
 
     def get_observation_space(self, obstacles: dict, goals: dict):

--- a/urdfenvs/sensors/sensor.py
+++ b/urdfenvs/sensors/sensor.py
@@ -2,24 +2,41 @@
 from typing import List
 from abc import abstractmethod
 
+from urdfenvs.sensors.physics_engine_interface import PhysicsEngineInterface, PybulletInterface, MujocoInterface
 
-class Sensor(object):
+class Sensor():
     """Abstract sensor class.
 
     This class serves as a blueprint for sensors. Every sensor must
     inherit from this class and implement the abstract methods.
     """
 
+    _name: str
+    _variance: float
+    _plotting_interval: int
+    _physics_engine: PhysicsEngineInterface
+
     def __init__(
-        self, name, variance: float = 0.0, plotting_interval: int = -1
+        self,
+        name: str,
+        variance: float = 0.0,
+        plotting_interval: int = -1,
+        physics_engine_name: str = 'pybullet',
     ):
         self._name = name
         self._variance = variance
         self._plotting_interval = plotting_interval
         self._call_counter = plotting_interval - 1
+        if physics_engine_name == 'pybullet':
+            self._physics_engine = PybulletInterface()
+        elif physics_engine_name == 'mujoco':
+            self._physics_engine = MujocoInterface()
 
     def name(self):
         return self._name
+
+    def set_data(self, data):
+        self._physics_engine.set_data(data)
 
     @abstractmethod
     def get_observation_size(self):

--- a/urdfenvs/urdf_common/helpers.py
+++ b/urdfenvs/urdf_common/helpers.py
@@ -26,23 +26,6 @@ def quaternion_between_vectors(v1, v2, ordering="wxyz"):
     return normed_quat
 
 
-class LinkIdNotFoundError(Exception):
-    pass
-
-
-def extract_link_id(robot, link_name: str):
-    number_links = pybullet.getNumJoints(robot)
-    joint_names = []
-    for i in range(number_links):
-        joint_name = pybullet.getJointInfo(robot, i)[1].decode("UTF-8")
-        joint_names.append(joint_name)
-        if joint_name == link_name:
-            return i
-    raise LinkIdNotFoundError(
-        f"Link with name {link_name} not found. "
-        f"Possible links are {joint_names}"
-    )
-
 
 class InvalidQuaternionOrderError(Exception):
     pass


### PR DESCRIPTION
Separates sensors from the physics engine to allow integration with mujoco.

**Rational**: In the aim of integrating mujoco as an alternative physics engine, this PR extracs the physics-engine-specifics from most of the sensor (all except for those relying on ray-casting). 

**Approach**: In a newly created class `PhysicsEngineInterface`, functions for extracting poses are implemented for the two physics engines. The sensor the use that class instance to query the physics engine for information.

**Example**: The existing examples are not affected by this change as the default is `pybullet`. In the `mujoco_example`, the new functionality can be seen. Note that some sensors may introduces a computational overhead.



