### PR TITLE
Ft mujoco lidar sensor

### DIFF
--- a/examples/mujoco_example.py
+++ b/examples/mujoco_example.py
@@ -6,6 +6,7 @@ from urdfenvs.generic_mujoco.generic_mujoco_env import GenericMujocoEnv
 from urdfenvs.generic_mujoco.generic_mujoco_robot import GenericMujocoRobot
 from urdfenvs.sensors.free_space_occupancy import FreeSpaceOccupancySensor
 from urdfenvs.sensors.full_sensor import FullSensor
+from urdfenvs.sensors.lidar import Lidar
 from urdfenvs.sensors.sdf_sensor import SDFSensor
 from urdfenvs.scene_examples.obstacles import sphereObst1, sphereObst2, wall_obstacles, cylinder_obstacle, dynamicSphereObst2
 from urdfenvs.scene_examples.goal import goal1
@@ -64,6 +65,14 @@ def run_generic_mujoco(n_steps: int = 1000, render: bool = True, goal: bool = Fa
         interval=100,
         physics_engine_name='mujoco',
     )
+    number_lidar_rays = 64
+    lidar_sensor = Lidar(
+        "base_link",
+        nb_rays=number_lidar_rays,
+        ray_length=5.0,
+        raw_data=False,
+        physics_engine_name='mujoco',
+    )
     if os.path.exists(ROBOTTYPE):
         shutil.rmtree(ROBOTTYPE)
     robot_model_original = RobotModel(ROBOTTYPE, ROBOTMODEL)
@@ -78,7 +87,7 @@ def run_generic_mujoco(n_steps: int = 1000, render: bool = True, goal: bool = Fa
         robots,
         obstacle_list,
         goal_list,
-        sensors=[full_sensor, fsd_sensor, sdf_sensor],
+        sensors=[lidar_sensor, full_sensor, fsd_sensor, sdf_sensor],
         render=render,
     )
     ob, info = env.reset()
@@ -87,9 +96,9 @@ def run_generic_mujoco(n_steps: int = 1000, render: bool = True, goal: bool = Fa
     t = 0.0
     history = []
     for _ in range(n_steps):
-        action = action_mag * np.cos(env.t)
+        action = action_mag * np.cos(env.t) * 0
         ob, _, terminated, _, info = env.step(action)
-        #print(ob['robot_0'])
+        print(ob['robot_0']['LidarSensor'])
         history.append(ob)
         if terminated:
             print(info)

--- a/examples/mujoco_example.py
+++ b/examples/mujoco_example.py
@@ -4,6 +4,7 @@ import numpy as np
 from robotmodels.utils.robotmodel import RobotModel, LocalRobotModel
 from urdfenvs.generic_mujoco.generic_mujoco_env import GenericMujocoEnv
 from urdfenvs.generic_mujoco.generic_mujoco_robot import GenericMujocoRobot
+from urdfenvs.sensors.free_space_decomposition import FreeSpaceDecompositionSensor
 from urdfenvs.sensors.free_space_occupancy import FreeSpaceOccupancySensor
 from urdfenvs.sensors.full_sensor import FullSensor
 from urdfenvs.sensors.lidar import Lidar
@@ -73,6 +74,13 @@ def run_generic_mujoco(n_steps: int = 1000, render: bool = True, goal: bool = Fa
         raw_data=False,
         physics_engine_name='mujoco',
     )
+    free_space_decomp = FreeSpaceDecompositionSensor(
+        "base_link",
+        nb_rays=number_lidar_rays,
+        max_radius=10,
+        number_constraints=1,
+        physics_engine_name='mujoco',
+    )
     if os.path.exists(ROBOTTYPE):
         shutil.rmtree(ROBOTTYPE)
     robot_model_original = RobotModel(ROBOTTYPE, ROBOTMODEL)
@@ -87,7 +95,7 @@ def run_generic_mujoco(n_steps: int = 1000, render: bool = True, goal: bool = Fa
         robots,
         obstacle_list,
         goal_list,
-        sensors=[lidar_sensor, full_sensor, fsd_sensor, sdf_sensor],
+        sensors=[lidar_sensor, full_sensor, free_space_decomp, sdf_sensor],
         render=render,
     )
     ob, info = env.reset()
@@ -96,9 +104,9 @@ def run_generic_mujoco(n_steps: int = 1000, render: bool = True, goal: bool = Fa
     t = 0.0
     history = []
     for _ in range(n_steps):
-        action = action_mag * np.cos(env.t) * 0
+        action = action_mag * np.cos(env.t)
         ob, _, terminated, _, info = env.step(action)
-        print(ob['robot_0']['LidarSensor'])
+        #print(ob['robot_0'])
         history.append(ob)
         if terminated:
             print(info)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2735,4 +2735,4 @@ keyboard = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "75af935b1ce54d31a8e8d21fb65a0fd1685ab3edd7b51a788a01ba74d29f8bbd"
+content-hash = "247bf6f0d1bb5ea8f4c72d5dabedcd018abe3a00bea4dc91f6b63db59bec0615"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "urdfenvs"
-version = "0.9.4"
+version = "0.9.5"
 description = "Simple simulation environment for robots, based on the urdf files."
 authors = ["Max Spahn <m.spahn@tudelft.nl>"]
 maintainers = [
@@ -24,6 +24,7 @@ mpscenes = "^0.4.4"
 gymnasium = "^0.29.1"
 dill = "^0.3.7"
 robotmodels = "^0.1.2"
+scipy = "^1.9.0"
 
 [tool.poetry.extras]
 keyboard = ["pynput", "multiprocess"]

--- a/urdfenvs/generic_mujoco/generic_mujoco_env.py
+++ b/urdfenvs/generic_mujoco/generic_mujoco_env.py
@@ -313,7 +313,7 @@ class GenericMujocoEnv(utils.EzPickle):
             fromto_string += " " + " ".join(map(str, end_position))
 
             site_values = {
-              "name":f"rf_{i}",
+              "name":f"{sensor.name()}_rf_{i}",
               "type":"capsule",
               "size":"0.01",
               "fromto": fromto_string,
@@ -322,8 +322,8 @@ class GenericMujocoEnv(utils.EzPickle):
 
 
             rangefinder_values = {
-                'name': f'lidar_{i}',
-                'site': f'rf_{i}',
+                'name': f'{sensor.name()}_{i}',
+                'site': f'{sensor.name()}_rf_{i}',
                 'cutoff': str(sensor._ray_length + 0.01/2),
             }
             range_finder = ET.SubElement(sensor_element, 'rangefinder', rangefinder_values)

--- a/urdfenvs/generic_mujoco/generic_mujoco_env.py
+++ b/urdfenvs/generic_mujoco/generic_mujoco_env.py
@@ -6,12 +6,14 @@ import xml.dom.minidom as minidom
 import gymnasium as gym
 from gymnasium import utils
 import mujoco
+from urdfenvs.sensors.lidar import Lidar
 from urdfenvs.sensors.sensor import Sensor
 
 from urdfenvs.urdf_common.urdf_env import (
     check_observation,
     WrongObservationError,
 )
+
 from urdfenvs.generic_mujoco.generic_mujoco_robot import GenericMujocoRobot
 from urdfenvs.generic_mujoco.mujoco_rendering import MujocoRenderer
 from mpscenes.obstacles.collision_obstacle import CollisionObstacle
@@ -23,6 +25,9 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 DEFAULT_SIZE = 480
+
+class LinkIdNotFoundError(Exception):
+    pass
 
 
 class GenericMujocoEnv(utils.EzPickle):
@@ -54,6 +59,10 @@ class GenericMujocoEnv(utils.EzPickle):
         self._xml_file = robots[0].xml_file
         self._obstacles = obstacles
         self._goals = goals
+        if not sensors:
+            self._sensors = []
+        else:
+            self._sensors = sensors
         self.add_scene()
         self._t = 0.0
 
@@ -69,12 +78,8 @@ class GenericMujocoEnv(utils.EzPickle):
         self.frame_skip = frame_skip
         self._initialize_simulation()
 
-        if not sensors:
-            self._sensors = []
-        else:
-            self._sensors = sensors
-            for sensor in self._sensors:
-                sensor.set_data(self.data)
+        for sensor in self._sensors:
+            sensor.set_data(self.data)
 
         assert self.metadata["render_modes"] == [
             "human",
@@ -271,8 +276,58 @@ class GenericMujocoEnv(utils.EzPickle):
             self.add_obstacle(obstacle, worldbody)
         for sub_goal in self._goals:
             self.add_sub_goal(sub_goal, worldbody)
+        for sensor in self._sensors:
+            if isinstance(sensor, Lidar):
+                self.add_range_finder(sensor,root)
+
         self._xml_file = self._xml_file[:-4] + "_temp.xml"
         tree.write(self._xml_file)
+
+
+    def add_range_finder(self, sensor: Lidar, root: ET.Element) -> None:
+        lidar_link = None
+        for body in root.iter('body'):
+            if body.attrib.get('name') == sensor._link_name:
+                lidar_link = body
+                break
+        if not lidar_link:
+            raise LinkIdNotFoundError(
+                f"Link '{sensor._link_name}' not found in xml. It might be in an include."
+            )
+
+        lidar_link = body
+        sensor_element = ET.Element('sensor')
+        for i in range(sensor._nb_rays):
+            angle = i/sensor._nb_rays * np.pi * 2
+            start_position = np.array([
+                np.cos(angle) * 0.00,
+                np.sin(angle) * 0.00,
+                0.0,
+            ])
+            end_position = np.array([
+                np.cos(angle) * 0.01,
+                np.sin(angle) * 0.01,
+                0.0,
+            ])
+            fromto_string = " ".join(map(str, start_position)) 
+            fromto_string += " " + " ".join(map(str, end_position))
+
+            site_values = {
+              "name":f"rf_{i}",
+              "type":"capsule",
+              "size":"0.01",
+              "fromto": fromto_string,
+            }
+            site = ET.SubElement(lidar_link, "site", site_values)
+
+
+            rangefinder_values = {
+                'name': f'lidar_{i}',
+                'site': f'rf_{i}',
+                'cutoff': str(sensor._ray_length + 0.01/2),
+            }
+            range_finder = ET.SubElement(sensor_element, 'rangefinder', rangefinder_values)
+        root.append(sensor_element)
 
 
     def add_obstacle(
@@ -304,10 +359,8 @@ class GenericMujocoEnv(utils.EzPickle):
             "rgba": "0 1 0 0.3",
             "pos": " ".join([str(i) for i in sub_goal.position()]),
             "size": str(sub_goal.epsilon()),
-            "contype": str(0),
-            "conaffinity": str(0),
         }
-        ET.SubElement(worldbody, "geom", geom_values)
+        ET.SubElement(worldbody, "site", geom_values)
 
     def _get_obs(self):
         observation = {

--- a/urdfenvs/sensors/free_space_decomposition.py
+++ b/urdfenvs/sensors/free_space_decomposition.py
@@ -18,6 +18,7 @@ class FreeSpaceDecompositionSensor(FSDSensor, Lidar):
         plotting_interval_fsd: int = -1,
         variance: float = 0.0,
         planar_visualization: bool = True,
+        physics_engine_name: str = 'pybullet'
     ):
         FSDSensor.__init__(
             self,
@@ -26,6 +27,7 @@ class FreeSpaceDecompositionSensor(FSDSensor, Lidar):
             plotting_interval_fsd=plotting_interval_fsd,
             variance=variance,
             planar_visualization=planar_visualization,
+            physics_engine_name=physics_engine_name,
         )
         Lidar.__init__(
             self,
@@ -36,6 +38,7 @@ class FreeSpaceDecompositionSensor(FSDSensor, Lidar):
             angle_limits=angle_limits,
             variance=variance,
             plotting_interval=plotting_interval,
+            physics_engine_name=physics_engine_name,
         )
         self._name = "FreeSpaceDecompSensor"
 

--- a/urdfenvs/sensors/fsd_sensor.py
+++ b/urdfenvs/sensors/fsd_sensor.py
@@ -16,11 +16,13 @@ class FSDSensor(Sensor):
         plotting_interval_fsd: int = -1,
         variance: float = 0.0,
         planar_visualization: bool = True,
+        physics_engine_name: str = 'pybullet'
     ):
         Sensor.__init__(
             self,
             "AbstractFSDSensor",
             variance=variance,
+            physics_engine_name=physics_engine_name,
         )
         self._fsd = FreeSpaceDecomposition(
             np.array([0.0, 0.0, 0.0]),


### PR DESCRIPTION
Adds lidar sensor to mujoco using rangefinder. Separates physics engine from lidar sensor.
Adds scipy as dependency to convert different spatial representations.
Adds lidar sensor to mujoco example.