### PR TITLE
Fix reset_obstacles() crashes for URDF obstacles

### DIFF
--- a/urdfenvs/urdf_common/urdf_env.py
+++ b/urdfenvs/urdf_common/urdf_env.py
@@ -396,8 +396,8 @@ class UrdfEnv(gym.Env):
         for obst_id, obstacle in self._obsts.items():
             if obstacle.type() == "urdf":
                 pos = obstacle.position()
-                vel = obstacle.velocity()
-                ori = [1.0, 0.0, 0.0, 0.0]
+                vel = obstacle.velocity() # [0.0, 0.0, 0.0]
+                ori = obstacle.orientation().tolist()
             else:
                 pos = obstacle.position(t=0).tolist()
                 vel = obstacle.velocity(t=0).tolist()

--- a/urdfenvs/urdf_common/urdf_env.py
+++ b/urdfenvs/urdf_common/urdf_env.py
@@ -396,7 +396,8 @@ class UrdfEnv(gym.Env):
         for obst_id, obstacle in self._obsts.items():
             if obstacle.type() == "urdf":
                 pos = obstacle.position()
-                vel = obstacle.position()
+                vel = obstacle.velocity()
+                ori = [1.0, 0.0, 0.0, 0.0]
             else:
                 pos = obstacle.position(t=0).tolist()
                 vel = obstacle.velocity(t=0).tolist()


### PR DESCRIPTION
Fix Issue #280.

1. Ensures that the local variable `ori` in `reset_obstacles` exists when adding a urdf obstacle as the first obstacle;
2. Fix the `vel` assignment to prevent the object from drifting.