### PR TITLE
Resolved #283, crash due to contact is None

### DIFF
--- a/urdfenvs/urdf_common/urdf_env.py
+++ b/urdfenvs/urdf_common/urdf_env.py
@@ -217,7 +217,10 @@ class UrdfEnv(gym.Env):
 
         pybullet.stepSimulation(self._cid)
         for robot_id, robot in enumerate(self._robots):
-            contacts = pybullet.getContactPoints(robot._robot)
+            contacts = pybullet.getContactPoints(
+                bodyA=robot._robot,
+                physicsClientId=self._cid
+            ) or []
             for contact_info in contacts:
                 body_b = contact_info[2]
                 if body_b in self._obsts:


### PR DESCRIPTION
resolved #283.

in `urdf_common/urdf_env.py:219`
```bash
# git diff
-            contacts = pybullet.getContactPoints(robot._robot)
+            contacts = pybullet.getContactPoints(
+                bodyA=robot._robot,
+                physicsClientId=self._cid
+            ) or []
```

1. specified `physicsClientId=self._cid`, so pybullet won't use wrong physicsClientId when others is also connecting pybullet.
2. add protection `or []`, so even when contacts is None, it won't crash the whole program.